### PR TITLE
Add integration into zsh shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,48 +44,47 @@ version: '2'
 
 environment:
   COMPOSE_EXT: development
-  RAILS_ENV: development
 
 compose:
   files:
     - docker/docker-compose.yml
     - docker/docker-compose.$COMPOSE_EXT.yml
     - docker/docker-compose.$DIP_OS.yml
-  project_name: bear-$RAILS_ENV
+  project_name: bear
 
 interaction:
   sh:
-    service: foo-app
+    service: app
     compose_run_options: [no-deps]
 
   bundle:
-    service: foo-app
+    service: app
     command: bundle
 
   rake:
-    service: foo-app
+    service: app
     command: bundle exec rake
 
   rspec:
-    service: foo-app
+    service: app
     environment:
       RAILS_ENV: test
     command: bundle exec rspec
 
   rails:
-    service: foo-app
+    service: app
     command: bundle exec rails
     subcommands:
       s:
-        service: foo-web
+        service: web
         compose_method: up
 
   psql:
-    service: foo-app
+    service: app
     command: psql -h pg -U postgres
 
 provision:
-  - dip compose up -d foo-pg foo-redis
+  - dip compose up -d pg redis
   - dip bundle install
   - dip rake db:migrate
 ```
@@ -119,6 +118,28 @@ dip compose COMMAND [OPTIONS]
 
 dip compose up -d redis
 ```
+
+### Integration with shell
+
+Dip can be injected into your current shell. For now, it supported ZSH only.
+
+Inject Dip rc file (by default it saved to ~/.dip_shell_rc) into ZSH:
+
+```sh
+source $(dip console)
+```
+
+After that you can type commands without `dip` prefix. For example:
+
+```sh
+d> <run-command> *any-args
+d> compose *any-compose-arg
+d> up <service>
+d> down
+d> provision
+```
+
+When you change the current directory, all shell aliases will be automatically removed. But when you will enter back to a directory with a dip.yml file, then shell aliases will be renewed.
 
 ### dip ssh
 

--- a/lib/dip.rb
+++ b/lib/dip.rb
@@ -15,6 +15,11 @@ module Dip
       @env ||= Dip::Environment.new(config.exist? ? config.environment : {})
     end
 
+    def bin_path
+      # TODO: Maybe there's a better way?
+      $PROGRAM_NAME.start_with?("./") ? File.expand_path($PROGRAM_NAME) : $PROGRAM_NAME
+    end
+
     %w(test debug).each do |key|
       define_method("#{key}?") do
         ENV["DIP_ENV"] == key

--- a/lib/dip/cli.rb
+++ b/lib/dip/cli.rb
@@ -99,5 +99,9 @@ module Dip
     require_relative 'cli/nginx'
     desc "nginx", "Nginx reverse proxy server"
     subcommand :nginx, Dip::CLI::Nginx
+
+    require_relative 'cli/console'
+    desc "console", "Integrate Dip commands into shell (only ZSH is supported now)"
+    subcommand :console, Dip::CLI::Console
   end
 end

--- a/lib/dip/cli/console.rb
+++ b/lib/dip/cli/console.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'thor'
+require_relative "../commands/console"
+
+module Dip
+  class CLI
+    class Console < Thor
+      desc "start", "Integrate Dip into current shell"
+      method_option :help, aliases: '-h', type: :boolean,
+                           desc: 'Display usage information'
+      def start
+        if options[:help]
+          invoke :help, ['start']
+        else
+          Dip::Commands::Console::Start.new.execute
+        end
+      end
+
+      default_task :start
+
+      desc "inject", "Inject aliases"
+      method_option :help, aliases: '-h', type: :boolean,
+                           desc: 'Display usage information'
+      def inject
+        if options[:help]
+          invoke :help, ['inject']
+        else
+          Dip::Commands::Console::Inject.new.execute
+        end
+      end
+    end
+  end
+end

--- a/lib/dip/commands/console.rb
+++ b/lib/dip/commands/console.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require_relative '../command'
+
+module Dip
+  module Commands
+    module Console
+      class Start < Dip::Command
+        def execute
+          File.write(rc_file, script_content)
+
+          puts rc_file
+        end
+
+        private
+
+        def rc_file
+          @rc_file ||= "#{Dir.home}/.dip_shell_rc"
+        end
+
+        def script_content
+          <<-SH.gsub(/^[ ]{12}/, '')
+            if [ "$DIP_SHELL" != "1" ]; then
+              export PS1="${PS1}d> "
+              export DIP_SHELL=1
+            fi
+
+            function _dip_remove_aliases() {
+              # will be redefined
+            }
+
+            function _dip_source_aliases() {
+              #{Dip.bin_path} console inject | source /dev/stdin
+            }
+
+            _dip_source_aliases
+
+            function chpwd() {
+              _dip_remove_aliases
+              _dip_source_aliases
+            }
+          SH
+        end
+      end
+
+      class Inject < Dip::Command
+        def initialize
+          @aliases = []
+          @out = []
+        end
+
+        def execute
+          if Dip.config.exist?
+            alias_interaction if Dip.config.interaction
+            alias_compose
+            add_alias("provision")
+          end
+
+          fill_removing_aliases
+
+          puts @out.join("\n\n")
+        end
+
+        private
+
+        def alias_interaction
+          Dip.config.interaction.keys.each do |name|
+            add_alias(name)
+          end
+        end
+
+        def alias_compose
+          %w(compose up down).each do |name|
+            add_alias(name)
+          end
+        end
+
+        def add_alias(name)
+          @aliases << name
+          @out << "function #{name}() { #{Dip.bin_path} #{name} $@; }"
+        end
+
+        def fill_removing_aliases
+          @out << "function _dip_remove_aliases() { \n" \
+                  "#{@aliases.map { |a| "  unset -f #{a}" }.join("\n")} " \
+                  "\n}"
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/dip/commands/console_spec.rb
+++ b/spec/lib/dip/commands/console_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "shellwords"
+require "dip/cli"
+require "dip/commands/console"
+
+describe Dip::Commands::Console do
+  let(:cli) { Dip::CLI }
+
+  describe Dip::Commands::Console::Start do
+    context "when execute without start" do
+      subject { cli.start "console".shellsplit }
+
+      it { expect { subject }.to output(/.dip_shell_rc$/).to_stdout }
+    end
+  end
+
+  describe Dip::Commands::Console::Inject do
+    subject { cli.start "console inject".shellsplit }
+
+    context "when provision commands are empty" do
+      it { expect { subject }.to output(/function compose/).to_stdout }
+      it { expect { subject }.to output(/unset -f compose/).to_stdout }
+      it { expect { subject }.to output(/function up/).to_stdout }
+      it { expect { subject }.to output(/unset -f up/).to_stdout }
+      it { expect { subject }.to output(/function down/).to_stdout }
+      it { expect { subject }.to output(/unset -f down/).to_stdout }
+      it { expect { subject }.to output(/function provision/).to_stdout }
+      it { expect { subject }.to output(/unset -f provision/).to_stdout }
+    end
+
+    context "when has provison command", config: true do
+      let(:config) { {interaction: commands} }
+      let(:commands) { {bash: {service: "app"}, rails: {service: "app", command: "rails"}} }
+
+      it { expect { subject }.to output(/function bash/).to_stdout }
+      it { expect { subject }.to output(/unset -f bash/).to_stdout }
+      it { expect { subject }.to output(/function rails/).to_stdout }
+      it { expect { subject }.to output(/unset -f rails/).to_stdout }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ ENV["DIP_ENV"] = "test"
 
 require "simplecov"
 SimpleCov.start do
-  # minimum_coverage 97
+  minimum_coverage 90
 end
 
 require "pry-byebug"


### PR DESCRIPTION
With this pull-request Dip can be integrated into ZSH shell. This amazing change will push to use Docker, even the most old-school programmers. See updated README.md for details.