### PR TITLE
fix: Don's use run vars in up-mode

### DIFF
--- a/lib/dip/commands/run.rb
+++ b/lib/dip/commands/run.rb
@@ -33,8 +33,12 @@ module Dip
 
         compose_argv = []
         compose_argv.concat(prepare_compose_run_options(command[:compose_run_options]))
-        compose_argv.concat(run_vars)
-        compose_argv << "--rm" if compose_method == "run"
+
+        if compose_method == "run"
+          compose_argv.concat(run_vars)
+          compose_argv << "--rm"
+        end
+
         compose_argv << command.fetch(:service).to_s
         compose_argv += command[:command].to_s.shellsplit
         compose_argv.concat(@argv)

--- a/spec/lib/dip/commands/run_spec.rb
+++ b/spec/lib/dip/commands/run_spec.rb
@@ -42,8 +42,19 @@ describe Dip::Commands::Run, config: true do
   end
 
   context "when run vars" do
-    before { cli.start "FOO=foo run bash".shellsplit }
-    it { expected_exec("docker-compose", ["run", "-e", "FOO=foo", "--rm", "app"]) }
+    context "when execute through `compose run`" do
+      before { cli.start "FOO=foo run bash".shellsplit }
+
+      it { expected_exec("docker-compose", ["run", "-e", "FOO=foo", "--rm", "app"]) }
+    end
+
+    context "when execute through `compose up`" do
+      let(:commands) { {rails: {service: "app", command: "rails", compose_method: "up"}} }
+
+      before { cli.start "FOO=foo run rails server".shellsplit }
+
+      it { expected_exec("docker-compose", ["up", "app", "rails", "server"]) }
+    end
   end
 
   context "when config with environment vars" do


### PR DESCRIPTION
# Context

The `-e` is an illegal argument for the `docker-compose up`

## Related tickets

#52

# What's inside

- [x] Check the compose method in the runner

# Checklist:

- [x] I have added tests
