### PR TITLE
feat: Add ability to inject aliases into Bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ Command line utility that gives the "native" interaction with applications confi
 
 ## Integration with shell
 
-Dip can be injected into current shell. For now, it supported ZSH only.
+Dip can be injected into current shell (ZSH or Bash).
 
 ```sh
-dip console | source /dev/stdin
+eval "$(dip console)"
 ```
 
 After that we can type commands without `dip` prefix. For example:
@@ -45,6 +45,9 @@ Also, in shell mode Dip is trying to determine passed manually environment varia
 ```sh
 VERSION=20180515103400 rails db:migrate:down
 ```
+
+You could add this `eval` at the end of your `~/.zshrc`, or `~/.bashrc`, or `~/.bash_profile`. 
+After that, it will be automatically applied when you open your preferred terminal.
 
 ## Installation
 

--- a/lib/dip/cli.rb
+++ b/lib/dip/cli.rb
@@ -50,12 +50,17 @@ module Dip
       end
     end
 
-    desc "up [OPTIONS] SERVICE", "Run docker-compose up command"
+    desc "up [OPTIONS] SERVICE", "Run `docker-compose up` command"
     def up(*argv)
       compose("up", *argv)
     end
 
-    desc "down [OPTIONS]", "Run docker-compose down command"
+    desc "stop [OPTIONS] SERVICE", "Run `docker-compose stop` command"
+    def stop(*argv)
+      compose("stop", *argv)
+    end
+
+    desc "down [OPTIONS]", "Run `docker-compose down` command"
     def down(*argv)
       compose("down", *argv)
     end
@@ -97,7 +102,7 @@ module Dip
     subcommand :nginx, Dip::CLI::Nginx
 
     require_relative 'cli/console'
-    desc "console", "Integrate Dip commands into shell (only ZSH is supported now)"
+    desc "console", "Integrate Dip commands into shell (only ZSH and Bash is supported)"
     subcommand :console, Dip::CLI::Console
   end
 end

--- a/lib/dip/commands/console.rb
+++ b/lib/dip/commands/console.rb
@@ -18,6 +18,48 @@ module Dip
             export DIP_EARLY_ENVS=#{ENV.keys.join(',')}
             export DIP_PROMPT_TEXT="ⅆ"
 
+            function dip_clear() {
+              # just stub, will be redefined after injecting aliases
+              true
+            }
+
+            function dip_inject() {
+              eval "$(#{Dip.bin_path} console inject)"
+            }
+
+            function dip_reload() {
+              dip_clear
+              dip_inject
+            }
+
+            # Inspired by RVM
+            function __zsh_like_cd() {
+              \\typeset __zsh_like_cd_hook
+              if
+                builtin "$@"
+              then
+                for __zsh_like_cd_hook in chpwd "${chpwd_functions[@]}"
+                do
+                  if \\typeset -f "$__zsh_like_cd_hook" >/dev/null 2>&1
+                  then "$__zsh_like_cd_hook" || break # finish on first failed hook
+                  fi
+                done
+                true
+              else
+                return $?
+              fi
+            }
+
+            [[ -n "${ZSH_VERSION:-}" ]] ||
+            {
+              function cd()    { __zsh_like_cd cd    "$@" ; }
+              function popd()  { __zsh_like_cd popd  "$@" ; }
+              function pushd() { __zsh_like_cd pushd "$@" ; }
+            }
+
+            export -a chpwd_functions
+            [[ " ${chpwd_functions[*]} " == *" dip_reload "* ]] || chpwd_functions+=(dip_reload)
+
             if [[ "$ZSH_THEME" = "agnoster" ]]; then
               eval "`declare -f prompt_end | sed '1s/.*/_&/'`"
 
@@ -30,25 +72,14 @@ module Dip
               }
             fi
 
-            function dip_remove_aliases() {
-              # will be redefined
-            }
-
-            function dip_source_aliases() {
-              #{Dip.bin_path} console inject | source /dev/stdin
-            }
-
-            dip_source_aliases
-
-            function chpwd() {
-              dip_remove_aliases
-              dip_source_aliases
-            }
+            dip_reload
           SH
         end
       end
 
       class Inject < Dip::Command
+        attr_reader :out, :aliases
+
         def initialize
           @aliases = []
           @out = []
@@ -56,38 +87,27 @@ module Dip
 
         def execute
           if Dip::Config.exist?
-            alias_interaction if Dip.config.interaction
-            alias_compose
-            add_alias("provision")
+            add_aliases(*Dip.config.interaction.keys) if Dip.config.interaction
+            add_aliases("compose", "up", "stop", "down", "provision")
           end
 
-          fill_removing_aliases
+          clear_aliases
 
-          puts @out.join("\n\n")
+          puts out.join("\n\n")
         end
 
         private
 
-        def alias_interaction
-          Dip.config.interaction.keys.each do |name|
-            add_alias(name)
+        def add_aliases(*names)
+          names.each do |name|
+            aliases << name
+            out << "function #{name}() { #{Dip.bin_path} #{name} $@; }"
           end
         end
 
-        def alias_compose
-          %w(compose up down).each do |name|
-            add_alias(name)
-          end
-        end
-
-        def add_alias(name)
-          @aliases << name
-          @out << "function #{name}() { #{Dip.bin_path} #{name} $@; }"
-        end
-
-        def fill_removing_aliases
-          @out << "function dip_remove_aliases() { \n" \
-                  "#{@aliases.map { |a| "  unset -f #{a}" }.join("\n")} " \
+        def clear_aliases
+          out << "function dip_clear() { \n" \
+                  "#{aliases.any? ? aliases.map { |a| "  unset -f #{a}" }.join("\n") : 'true'} " \
                   "\n}"
         end
       end

--- a/spec/lib/dip/commands/console_spec.rb
+++ b/spec/lib/dip/commands/console_spec.rb
@@ -13,8 +13,9 @@ describe Dip::Commands::Console do
 
       it { expect { subject }.to output(/export DIP_SHELL=1/).to_stdout }
       it { expect { subject }.to output(/export DIP_EARLY_ENVS/).to_stdout }
-      it { expect { subject }.to output(/function dip_remove_aliases/).to_stdout }
-      it { expect { subject }.to output(/function dip_source_aliases/).to_stdout }
+      it { expect { subject }.to output(/function dip_clear/).to_stdout }
+      it { expect { subject }.to output(/function dip_inject/).to_stdout }
+      it { expect { subject }.to output(/function dip_reload/).to_stdout }
     end
   end
 
@@ -26,13 +27,15 @@ describe Dip::Commands::Console do
       it { expect { subject }.to output(/unset -f compose/).to_stdout }
       it { expect { subject }.to output(/function up/).to_stdout }
       it { expect { subject }.to output(/unset -f up/).to_stdout }
+      it { expect { subject }.to output(/function stop/).to_stdout }
+      it { expect { subject }.to output(/unset -f stop/).to_stdout }
       it { expect { subject }.to output(/function down/).to_stdout }
       it { expect { subject }.to output(/unset -f down/).to_stdout }
       it { expect { subject }.to output(/function provision/).to_stdout }
       it { expect { subject }.to output(/unset -f provision/).to_stdout }
     end
 
-    context "when has provison command", config: true do
+    context "when has provision command", config: true do
       let(:config) { {interaction: commands} }
       let(:commands) { {bash: {service: "app"}, rails: {service: "app", command: "rails"}} }
 


### PR DESCRIPTION
# Context

Want to support Bash for injecting Dip aliases by running `eval "$(dip console)"`.

# What's inside

- [x] Change `dip console` command. Emulate ZSH's `chpwd` command.
- [x] Add `dip stop` shortcut command

# Checklist:

- [x] I have added tests
- [x] I have made corresponding changes to the documentation
