### PR TITLE
fix: Don't show help for run and compose commands

### DIFF
--- a/lib/dip/cli.rb
+++ b/lib/dip/cli.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'thor'
+require 'dip/run_vars'
 
 module Dip
   class CLI < Thor
@@ -39,15 +40,9 @@ module Dip
     map %w(--version -v) => :version
 
     desc 'compose CMD [OPTIONS]', 'Run docker-compose commands'
-    method_option :help, aliases: '-h', type: :boolean,
-                         desc: 'Display usage information'
-    def compose(cmd, *argv)
-      if options[:help]
-        invoke :help, ['compose']
-      else
-        require_relative 'commands/compose'
-        Dip::Commands::Compose.new(cmd, argv).execute
-      end
+    def compose(*argv)
+      require_relative 'commands/compose'
+      Dip::Commands::Compose.new(*argv).execute
     end
 
     desc "up [OPTIONS] SERVICE", "Run `docker-compose up` command"
@@ -60,21 +55,15 @@ module Dip
       compose("stop", *argv)
     end
 
-    desc "down [OPTIONS]", "Run `docker-compose down` command"
+    desc "down all services [OPTIONS]", "Run `docker-compose down` command"
     def down(*argv)
       compose("down", *argv)
     end
 
     desc 'CMD or dip run CMD [OPTIONS]', 'Run configured command in a docker-compose service'
-    method_option :help, aliases: '-h', type: :boolean,
-                         desc: 'Display usage information'
-    def run(cmd, subcmd = nil, *argv)
-      if options[:help]
-        invoke :help, ['run']
-      else
-        require_relative 'commands/run'
-        Dip::Commands::Run.new(cmd, subcmd, argv).execute
-      end
+    def run(*argv)
+      require_relative 'commands/run'
+      Dip::Commands::Run.new(*argv).execute
     end
 
     desc "provision", "Execute commands within provision section"

--- a/lib/dip/commands/compose.rb
+++ b/lib/dip/commands/compose.rb
@@ -8,18 +8,17 @@ module Dip
     class Compose < Dip::Command
       DOCKER_EMBEDDED_DNS = "127.0.0.11"
 
-      def initialize(cmd, argv = [])
-        @cmd = cmd
+      attr_reader :argv, :config
+
+      def initialize(*argv)
         @argv = argv
         @config = ::Dip.config.compose || {}
       end
 
       def execute
-        compose_argv = Array(find_files) + Array(find_project_name)
-        compose_argv << @cmd
-        compose_argv += @argv
-
         Dip.env["DIP_DNS"] ||= find_dns
+
+        compose_argv = Array(find_files) + Array(find_project_name) + argv
 
         shell("docker-compose", compose_argv)
       end
@@ -27,7 +26,7 @@ module Dip
       private
 
       def find_files
-        return unless (files = @config[:files])
+        return unless (files = config[:files])
 
         if files.is_a?(Array)
           files.each_with_object([]) do |file_name, memo|
@@ -41,7 +40,7 @@ module Dip
       end
 
       def find_project_name
-        return unless (project_name = @config[:project_name])
+        return unless (project_name = config[:project_name])
 
         if project_name.is_a?(String)
           project_name = ::Dip.env.interpolate(project_name)

--- a/lib/dip/commands/run.rb
+++ b/lib/dip/commands/run.rb
@@ -7,7 +7,7 @@ require_relative 'compose'
 module Dip
   module Commands
     class Run < Dip::Command
-      def initialize(cmd, subcmd = nil, argv = [])
+      def initialize(cmd, subcmd = nil, *argv)
         @cmd = cmd.to_sym
         @subcmd = subcmd.to_sym if subcmd
         @argv = argv
@@ -43,7 +43,7 @@ module Dip
         compose_argv += command[:command].to_s.shellsplit
         compose_argv.concat(@argv)
 
-        Dip::Commands::Compose.new(compose_method, compose_argv).execute
+        Dip::Commands::Compose.new(compose_method, *compose_argv).execute
       end
       # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 


### PR DESCRIPTION
# Context

We should be able to see help banners from docker-compose and any running command.

# What's inside

- [x] Remove the `--help` option

# Checklist:

- [x] I have added tests
