### PR TITLE
Fix passing env vars through argv

### DIFF
--- a/lib/dip/run_vars.rb
+++ b/lib/dip/run_vars.rb
@@ -17,8 +17,6 @@ module Dip
     def initialize(argv, env = ENV)
       @argv = argv
       @env = env
-
-      self.class.env.clear
     end
 
     def call
@@ -32,7 +30,7 @@ module Dip
       return if early_envs.empty?
 
       (env.keys - early_envs).each do |key|
-        next if env_excluded?(key)
+        next if ignore_var?(key)
 
         self.class.env[key] = env[key]
       end
@@ -56,7 +54,7 @@ module Dip
       @early_envs ||= env["DIP_EARLY_ENVS"].to_s.split(",")
     end
 
-    def env_excluded?(key)
+    def ignore_var?(key)
       key.start_with?("DIP_", "_")
     end
   end

--- a/spec/lib/dip/run_vars_spec.rb
+++ b/spec/lib/dip/run_vars_spec.rb
@@ -8,9 +8,17 @@ describe Dip::RunVars do
   end
 
   context "when env vars in argv" do
-    specify do
+    it "parses them and stores in class var" do
       expect(described_class.call(%w(FOO=foo BAR=bar run rspec))).to eq %w(run rspec)
       expect(described_class.env).to include("FOO" => "foo", "BAR" => "bar")
+    end
+
+    context "and call multiple times" do
+      it "doesn't reset previous vars" do
+        expect(described_class.call(%w(FOO=foo BAR=bar run rspec))).to eq %w(run rspec)
+        expect(described_class.call(%w(run rspec))).to eq %w(run rspec)
+        expect(described_class.env).to include("FOO" => "foo", "BAR" => "bar")
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,6 +43,7 @@ RSpec.configure do |config|
 
   config.before do
     Dip.reset!
+    Dip::RunVars.env.clear
   end
 
   Kernel.srand config.seed


### PR DESCRIPTION
# Context

Fixed regression when passing env vars through argv (e.g. `dip VERSION=20190101 rake db:migrate:down`)

## Related tickets

Closes #63

# What's inside

- [x] Don't clear Dip::RunVars every call

# Checklist:

- [x] I have added tests
