### PR TITLE
List command; Ruby version; Dip version checker

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ AllCops:
   Exclude:
     - tmp/**/*
     - vendor/**/*
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.3
 
 Documentation:
   Enabled: false
@@ -55,3 +55,9 @@ Layout/DotPosition:
 
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
+
+Metrics/AbcSize:
+  Max: 30
+
+Metrics/MethodLength:
+  Max: 15

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 
 rvm:
-  - 2.6
+  - 2.3
 
 os:
   - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,15 +13,14 @@ branches:
     - /^v\d+\.\d+\.\d+/
 
 stages:
+  # Skipping. I don't know how to run test stage only on linux.
+  - name: test
+    if: 1 = 2
   - check
-  - test
   - name: build-on-linux
     if: tag IS present
   - name: build-on-osx
     if: tag IS present
-
-script:
-  - bundle exec rspec
 
 jobs:
   include:
@@ -32,6 +31,7 @@ jobs:
       script:
         - danger
         - bundle exec rubocop
+        - bundle exec rspec
 
     - stage: build-on-linux
       os: linux

--- a/Dangerfile
+++ b/Dangerfile
@@ -5,13 +5,15 @@ CHANGED_FILES = (git.added_files + git.modified_files).freeze
 ADDED_FILES = git.added_files.freeze
 
 Dir[File.join(__dir__, ".danger/*.rb")].each do |danger_rule_file|
-  danger_rule = danger_rule_file.gsub(%r{(^./.danger/|.rb)}, "")
-  $stdout.print "- #{danger_rule} "
-  eval File.read(danger_rule_file), binding, File.expand_path(danger_rule_file) # rubocop:disable Security/Eval
-  $stdout.puts "✅"
-rescue Exception => e # rubocop:disable Lint/RescueException
-  $stdout.puts "💥"
+  begin
+    danger_rule = danger_rule_file.gsub(%r{(^./.danger/|.rb)}, "")
+    $stdout.print "- #{danger_rule} "
+    eval File.read(danger_rule_file), binding, File.expand_path(danger_rule_file) # rubocop:disable Security/Eval
+    $stdout.puts "✅"
+  rescue StandardError => e
+    $stdout.puts "💥"
 
-  raise "Danger rule :#{danger_rule} failed with exception: #{e.message}\n" \
-        "Backtrace: \n#{e.backtrace.join("\n")}"
+    raise "Danger rule :#{danger_rule} failed with exception: #{e.message}\n" \
+          "Backtrace: \n#{e.backtrace.join("\n")}"
+  end
 end

--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ Below is an example of a real config.
 Also, you can check out examples in the top.
 
 ```yml
-version: '2'
+# Required minimum dip version
+version: '4'
 
 environment:
   COMPOSE_EXT: development
@@ -116,32 +117,39 @@ compose:
 
 interaction:
   bash:
+    description: Open the Bash shell in app's container
     service: app
     compose_run_options: [no-deps]
 
   bundle:
+    description: Run Bundler commands
     service: app
     command: bundle
 
   rake:
+    description: Run Rake commands
     service: app
     command: bundle exec rake
 
   rspec:
+    description: Run Rspec commands
     service: app
     environment:
       RAILS_ENV: test
     command: bundle exec rspec
 
   rails:
+    description: Run Rails commands
     service: app
     command: bundle exec rails
     subcommands:
       s:
+        description: Run Rails server at http://localhost:3000
         service: web
         compose_run_options: [service-ports]
 
   psql:
+    description: Run Postgres psql console
     service: app
     command: psql -h pg -U postgres
 
@@ -165,6 +173,18 @@ dip run rake db:migrate
 ```sh
 dip rake db:migrate
 dip VERSION=12352452 rake db:rollback
+```
+
+### dip ls
+
+List al available run commands.
+
+```sh
+dip ls
+
+bash     # Open the Bash shell in app's container
+rails    # Run Rails command
+rails s  # Run Rails server at http://localhost:3000
 ```
 
 ### dip provision

--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ interaction:
   bash:
     description: Open the Bash shell in app's container
     service: app
-    compose_run_options: [no-deps]
+    compose:
+      run_options: [no-deps]
 
   bundle:
     description: Run Bundler commands
@@ -146,7 +147,15 @@ interaction:
       s:
         description: Run Rails server at http://localhost:3000
         service: web
-        compose_run_options: [service-ports]
+        compose:
+          run_options: [service-ports]
+
+  sidekiq:
+    description: Run sidekiq in background
+    service: worker
+    compose:
+      method: up
+      run_options: [detach]
 
   psql:
     description: Run Postgres psql console

--- a/dip.gemspec
+++ b/dip.gemspec
@@ -33,6 +33,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = '>= 2.3'
+
   spec.add_dependency "thor", "~> 0.20.0"
 
   spec.add_development_dependency "bundler", ">= 1.15"

--- a/dip.yml
+++ b/dip.yml
@@ -1,35 +1,40 @@
-version: '2'
+version: '4'
 
 compose:
   files:
     - docker-compose.yml
 
 interaction:
-  app:
+  bash:
+    description: Open the Bash shell in app's container
     service: app
+    command: /bin/bash
+
+  dev:
+    service: app
+    command: exit
     subcommands:
-      bash:
-        command: /bin/bash
       console:
+        description: Open the gem console
         command: ./bin/console
       clean:
+        description: Clean dependencies
         command: rm -rf Gemfile.lock
 
   bundle:
+    description: Run Bundler commands
     service: app
     command: bundle
 
   rspec:
+    description: Run Rspec commands
     service: app
     command: bundle exec rspec
 
   rubocop:
+    description: Run Rubocop commands
     service: app
     command: bundle exec rubocop
-
-  clean:
-    service: app
-    command: rm -rf Gemfile.lock
 
 provision:
   - dip app clean

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     environment:
       - GEM_HOME=/bundle
       - BUNDLE_PATH=/bundle
+      - HISTFILE=/app/tmp/.bash_history
     working_dir: /app
     volumes:
       - .:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   app:
-    image: ruby:2.5.1
+    image: ruby:2.3
     environment:
       - GEM_HOME=/bundle
       - BUNDLE_PATH=/bundle

--- a/lib/dip.rb
+++ b/lib/dip.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
+require "dip/errors"
 require "dip/config"
 require "dip/environment"
 
 module Dip
-  Error = Class.new(StandardError)
-
   class << self
     def config
       @config ||= Dip::Config.new

--- a/lib/dip/cli.rb
+++ b/lib/dip/cli.rb
@@ -39,6 +39,12 @@ module Dip
     end
     map %w(--version -v) => :version
 
+    desc 'ls', 'List available run commands'
+    def ls
+      require_relative 'commands/list'
+      Dip::Commands::List.new.execute
+    end
+
     desc 'compose CMD [OPTIONS]', 'Run docker-compose commands'
     def compose(*argv)
       require_relative 'commands/compose'

--- a/lib/dip/cli/dns.rb
+++ b/lib/dip/cli/dns.rb
@@ -22,7 +22,6 @@ module Dip
                             desc: 'Docker image name'
       method_option :domain, aliases: '-d', type: :string, default: "docker",
                              desc: 'Top level domain'
-      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       def up
         if options[:help]
           invoke :help, ['up']
@@ -37,7 +36,6 @@ module Dip
           ).execute
         end
       end
-      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
       desc "down", "Stop dnsdock container"
       method_option :help, aliases: '-h', type: :boolean,

--- a/lib/dip/cli/nginx.rb
+++ b/lib/dip/cli/nginx.rb
@@ -22,7 +22,6 @@ module Dip
                             desc: 'Docker image name'
       method_option :domain, aliases: '-d', type: :string, default: "docker",
                              desc: 'Top level domain'
-      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       def up
         if options[:help]
           invoke :help, ['up']
@@ -37,7 +36,6 @@ module Dip
           ).execute
         end
       end
-      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
       desc "down", "Stop nginx container"
       method_option :help, aliases: '-h', type: :boolean,

--- a/lib/dip/commands/list.rb
+++ b/lib/dip/commands/list.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative '../command'
+require_relative '../interaction_tree'
+
+module Dip
+  module Commands
+    class List < Dip::Command
+      def execute
+        tree = InteractionTree.new(Dip.config.interaction).list
+
+        longest_name = tree.keys.map(&:size).max
+
+        tree.each do |name, command|
+          puts "#{name.ljust(longest_name)}  ##{command[:description] ? ' ' + command[:description] : ''}"
+        end
+      end
+    end
+  end
+end

--- a/lib/dip/config.rb
+++ b/lib/dip/config.rb
@@ -3,6 +3,7 @@
 require "yaml"
 require "erb"
 
+require "dip/version"
 require "dip/ext/hash"
 
 using ActiveSupportHashHelpers
@@ -52,6 +53,13 @@ module Dip
       raise ArgumentError, "Dip config not found at path '#{self.class.path}'" unless self.class.exist?
 
       config = self.class.load_yaml
+
+      unless Gem::Version.new(Dip::VERSION) >= Gem::Version.new(config.fetch(:version))
+        raise VersionMismatchError, "Your dip version is `#{Dip::VERSION}`, " \
+                                    "but config requires minimum version `#{config[:version]}`. " \
+                                    "Please upgrade your dip!"
+      end
+
       config.deep_merge!(self.class.load_yaml(self.class.override_path))
 
       @config = config

--- a/lib/dip/errors.rb
+++ b/lib/dip/errors.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Dip
+  Error = Class.new(StandardError)
+
+  class VersionMismatchError < Dip::Error
+  end
+end

--- a/lib/dip/interaction_tree.rb
+++ b/lib/dip/interaction_tree.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "shellwords"
+require "dip/ext/hash"
+
+using ActiveSupportHashHelpers
+
+module Dip
+  class InteractionTree
+    def initialize(entries)
+      @entries = entries
+    end
+
+    def find(name, *argv)
+      entry = entries[name.to_sym]
+      return unless entry
+
+      commands = expand(name, entry)
+
+      keys = [name, *argv]
+      rest = []
+
+      keys.size.times do
+        if (command = commands[keys.join(" ")])
+          return {command: command, argv: rest.reverse!}
+        else
+          rest << keys.pop
+        end
+      end
+    end
+
+    def list
+      entries.each_with_object({}) do |(name, entry), memo|
+        expand(name.to_s, entry, tree: memo)
+      end
+    end
+
+    private
+
+    attr_reader :entries
+
+    def expand(name, entry, tree: {})
+      cmd = build_command(entry)
+
+      tree[name] = cmd
+
+      entry[:subcommands]&.each do |sub_name, sub_entry|
+        sub_command_defaults!(sub_entry)
+
+        expand("#{name} #{sub_name}", entry.deep_merge(sub_entry), tree: tree)
+      end
+
+      tree
+    end
+
+    def build_command(entry)
+      {
+        description: entry[:description],
+        service: entry.fetch(:service),
+        command: entry[:command],
+        environment: entry[:environment] || {},
+        compose: {
+          method: entry.dig(:compose, :method) || entry[:compose_method] || "run",
+          run_options: compose_run_options(entry.dig(:compose, :run_options) || entry[:compose_run_options])
+        }
+      }
+    end
+
+    def sub_command_defaults!(entry)
+      entry[:command] ||= nil
+      entry[:subcommands] ||= nil
+      entry[:description] ||= nil
+    end
+
+    def compose_run_options(value)
+      return [] unless value
+
+      value.map do |o|
+        o = o.start_with?("-") ? o : "--#{o}"
+        o.shellsplit
+      end.flatten
+    end
+  end
+end

--- a/spec/lib/dip/commands/list_spec.rb
+++ b/spec/lib/dip/commands/list_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "shellwords"
+require "dip/cli"
+require "dip/commands/list"
+
+describe Dip::Commands::List, config: true do
+  let(:config) { {interaction: commands} }
+  let(:commands) do
+    {
+      bash: {service: "app"},
+      rails: {
+        service: "app", command: "rails", description: "Run Rails command",
+        subcommands: {
+          s: {
+            description: "Run Rails server",
+            service: "web"
+          }
+        }
+      }
+    }
+  end
+  let(:cli) { Dip::CLI }
+
+  before { cli.start "ls".shellsplit }
+
+  it "prints all run commands" do
+    expected_output = <<~OUT
+      bash     #
+      rails    # Run Rails command
+      rails s  # Run Rails server
+    OUT
+
+    expect { cli.start "ls".shellsplit }.to output(expected_output).to_stdout
+  end
+end

--- a/spec/lib/dip/commands/run_spec.rb
+++ b/spec/lib/dip/commands/run_spec.rb
@@ -29,14 +29,28 @@ describe Dip::Commands::Run, config: true do
     it { expected_exec("docker-compose", ["run", "--rm", "app", "rails", "g", "migration", "add_index", "--force"]) }
   end
 
+  # backward compatibility
   context "when config with compose_run_options" do
     let(:commands) { {bash: {service: "app", compose_run_options: ["foo", "-bar", "--baz=qux"]}} }
     before { cli.start "run bash".shellsplit }
     it { expected_exec("docker-compose", ["run", "--foo", "-bar", "--baz=qux", "--rm", "app"]) }
   end
 
+  context "when config with compose: run_options" do
+    let(:commands) { {bash: {service: "app", compose: {run_options: ["foo", "-bar", "--baz=qux"]}}} }
+    before { cli.start "run bash".shellsplit }
+    it { expected_exec("docker-compose", ["run", "--foo", "-bar", "--baz=qux", "--rm", "app"]) }
+  end
+
+  # backward compatibility
   context "when config with compose_method" do
     let(:commands) { {rails: {service: "app", command: "rails", compose_method: "up"}} }
+    before { cli.start "run rails server".shellsplit }
+    it { expected_exec("docker-compose", ["up", "app", "rails", "server"]) }
+  end
+
+  context "when config with compose: method" do
+    let(:commands) { {rails: {service: "app", command: "rails", compose: {method: "up"}}} }
     before { cli.start "run rails server".shellsplit }
     it { expected_exec("docker-compose", ["up", "app", "rails", "server"]) }
   end


### PR DESCRIPTION
# Context

Want to list all available run commands.

## Related tickets

No ticket

# What's inside

- [x] Added endless nesting of subcommands
- [x] Added `dip ls` command to list all available run commands.
- [x] Dropped support for old Ruby less than 2.3.
- [x] Added a check of required Dip version by a config.
- [x] Added nesting to compose options

# Checklist:

- [x] I have added tests
- [x] I have made corresponding changes to the documentation
