### PR TITLE
Command default args

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ interaction:
   psql:
     description: Run Postgres psql console
     service: app
+    default_args: db_dev
     command: psql -h pg -U postgres
 
 provision:

--- a/lib/dip/commands/run.rb
+++ b/lib/dip/commands/run.rb
@@ -39,8 +39,12 @@ module Dip
         end
 
         compose_argv << command.fetch(:service)
-        compose_argv.concat(command[:command].to_s.shellsplit)
-        compose_argv.concat(argv)
+
+        unless (cmd = command[:command].to_s).empty?
+          compose_argv.concat(cmd.shellsplit)
+        end
+
+        compose_argv.concat(argv.any? ? argv : command[:default_args])
 
         compose_argv
       end

--- a/lib/dip/interaction_tree.rb
+++ b/lib/dip/interaction_tree.rb
@@ -60,6 +60,7 @@ module Dip
         description: entry[:description],
         service: entry.fetch(:service),
         command: entry[:command],
+        default_args: prepare_default_args(entry[:default_args]),
         environment: entry[:environment] || {},
         compose: {
           method: entry.dig(:compose, :method) || entry[:compose_method] || "run",
@@ -70,8 +71,22 @@ module Dip
 
     def sub_command_defaults!(entry)
       entry[:command] ||= nil
+      entry[:default_args] ||= nil
       entry[:subcommands] ||= nil
       entry[:description] ||= nil
+    end
+
+    def prepare_default_args(args)
+      return [] if args.nil?
+
+      case args
+      when Array
+        args
+      when String
+        args.shellsplit
+      else
+        raise ArgumentError, "Unknown type for default_args: #{args.inspect}"
+      end
     end
 
     def compose_run_options(value)

--- a/spec/lib/dip/commands/run_spec.rb
+++ b/spec/lib/dip/commands/run_spec.rb
@@ -6,7 +6,13 @@ require "dip/commands/run"
 
 describe Dip::Commands::Run, config: true do
   let(:config) { {interaction: commands} }
-  let(:commands) { {bash: {service: "app"}, rails: {service: "app", command: "rails"}} }
+  let(:commands) do
+    {
+      bash: {service: "app"},
+      rails: {service: "app", command: "rails"},
+      psql: {service: "postgres", command: "psql -h postgres", default_args: "db_dev"}
+    }
+  end
   let(:cli) { Dip::CLI }
 
   context "when run bash command" do
@@ -17,6 +23,16 @@ describe Dip::Commands::Run, config: true do
   context "when run shorthanded bash command" do
     before { cli.start ["bash"] }
     it { expected_exec("docker-compose", ["run", "--rm", "app"]) }
+  end
+
+  context "when run psql command without db name" do
+    before { cli.start "run psql".shellsplit }
+    it { expected_exec("docker-compose", ["run", "--rm", "postgres", "psql", "-h", "postgres", "db_dev"]) }
+  end
+
+  context "when run psql command with db name" do
+    before { cli.start "run psql db_test".shellsplit }
+    it { expected_exec("docker-compose", ["run", "--rm", "postgres", "psql", "-h", "postgres", "db_test"]) }
   end
 
   context "when run rails command" do


### PR DESCRIPTION
# Context

Want to run a command with default arguments unless they have given manually.

## Related tickets

No

# What's inside

- [x] Added a key `default_args` to the command schema.

# Checklist:

- [x] I have added tests
- [x] I have made corresponding changes to the documentation
