### PR TITLE
Find dip.yml in the nearest parent directory

### DIFF
--- a/.pryrc
+++ b/.pryrc
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+Pry.config.history.should_save = true
+Pry.config.history.file = "#{__dir__}/tmp/.pry_history"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,17 +5,11 @@ AllCops:
     - vendor/**/*
   TargetRubyVersion: 2.3
 
-Documentation:
-  Enabled: false
-
 Metrics/BlockLength:
   Exclude:
     - simple_contracts.gemspec
     - Gemfile
     - spec/**/*
-
-Metrics/LineLength:
-  Max: 120
 
 Metrics/ClassLength:
   Max: 300
@@ -30,6 +24,9 @@ Style/PercentLiteralDelimiters:
   Enabled: false
 
 Security/MarshalLoad:
+  Enabled: false
+
+Style/Documentation:
   Enabled: false
 
 Style/DoubleNegation:
@@ -49,6 +46,9 @@ Naming/PredicateName:
 
 Naming/MemoizedInstanceVariableName:
   Enabled: false
+
+Layout/LineLength:
+  Max: 120
 
 Layout/DotPosition:
   EnforcedStyle: trailing

--- a/README.md
+++ b/README.md
@@ -234,6 +234,12 @@ You can pass in a custom environment variable into a container:
 dip VERSION=12352452 rake db:rollback
 ```
 
+Use options `-p, --publish=[]` if you need to additionally publish a container's port(s) to the host unless this behaviour is not configured at dip.yml:
+
+```sh
+dip run -p 3000:3000 bundle exec rackup config.ru 
+```
+
 ### dip ls
 
 List all available run commands.

--- a/dip.yml
+++ b/dip.yml
@@ -10,16 +10,10 @@ interaction:
     service: app
     command: /bin/bash
 
-  dev:
+  pry:
+    description: Open Pry console
     service: app
-    command: exit
-    subcommands:
-      console:
-        description: Open the gem console
-        command: ./bin/console
-      clean:
-        description: Clean dependencies
-        command: rm -rf Gemfile.lock
+    command: ./bin/console
 
   bundle:
     description: Run Bundler commands
@@ -37,5 +31,5 @@ interaction:
     command: bundle exec rubocop
 
 provision:
-  - dip app clean
+  - rm -rf Gemfile.lock
   - dip bundle install

--- a/exe/dip
+++ b/exe/dip
@@ -4,15 +4,15 @@
 lib_path = File.expand_path('../lib', __dir__)
 $LOAD_PATH.unshift(lib_path) unless $LOAD_PATH.include?(lib_path)
 
+begin
+  require 'pry-byebug' if ENV["DIP_ENV"] == "debug"
+rescue LoadError # rubocop:disable Lint/SuppressedException
+  # do nothing
+end
+
 require 'dip'
 require 'dip/cli'
 require 'dip/run_vars'
-
-begin
-  require 'pry-byebug' if Dip.debug?
-rescue LoadError
-  puts "pry-byebug not found!"
-end
 
 Signal.trap('INT') do
   warn("\n#{caller.join("\n")}: interrupted")

--- a/lib/dip.rb
+++ b/lib/dip.rb
@@ -11,7 +11,7 @@ module Dip
     end
 
     def env
-      @env ||= Dip::Environment.new(Dip::Config.exist? ? config.environment : {})
+      @env ||= Dip::Environment.new(config.exist? ? config.environment : {})
     end
 
     def bin_path

--- a/lib/dip/cli.rb
+++ b/lib/dip/cli.rb
@@ -32,7 +32,7 @@ module Dip
       end
     end
 
-    stop_on_unknown_option! :up
+    stop_on_unknown_option! :run
 
     desc 'version', 'dip version'
     def version
@@ -68,10 +68,17 @@ module Dip
       compose("down", *argv)
     end
 
-    desc 'CMD or dip run CMD [OPTIONS]', 'Run configured command in a docker-compose service'
+    desc 'run [OPTIONS] CMD [ARGS]', 'Run configured command in a docker-compose service. `run` prefix may be omitted'
+    method_option :publish, aliases: '-p', type: :string, repeatable: true,
+                            desc: "Publish a container's port(s) to the host"
+    method_option :help, aliases: '-h', type: :boolean, desc: 'Display usage information'
     def run(*argv)
-      require_relative 'commands/run'
-      Dip::Commands::Run.new(*argv).execute
+      if argv.empty? || options[:help]
+        invoke :help, ['run']
+      else
+        require_relative 'commands/run'
+        Dip::Commands::Run.new(*argv, publish: options[:publish]).execute
+      end
     end
 
     desc "provision", "Execute commands within provision section"

--- a/lib/dip/cli/base.rb
+++ b/lib/dip/cli/base.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Dip
+  class CLI
+    class Base < Thor
+      def self.exit_on_failure?
+        true
+      end
+    end
+  end
+end

--- a/lib/dip/cli/console.rb
+++ b/lib/dip/cli/console.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 require 'thor'
+require_relative "./base"
 require_relative "../commands/console"
 
 module Dip
   class CLI
-    class Console < Thor
+    class Console < Base
       desc "start", "Integrate Dip into current shell"
       method_option :help, aliases: '-h', type: :boolean,
                            desc: 'Display usage information'

--- a/lib/dip/cli/dns.rb
+++ b/lib/dip/cli/dns.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 require 'thor'
+require_relative "./base"
 require_relative "../commands/dns"
 
 module Dip
   class CLI
     # See more https://github.com/aacebedo/dnsdock
-    class DNS < Thor
+    class DNS < Base
       desc "up", "Run dnsdock container"
       method_option :help, aliases: '-h', type: :boolean,
                            desc: 'Display usage information'

--- a/lib/dip/cli/nginx.rb
+++ b/lib/dip/cli/nginx.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 require 'thor'
+require_relative "./base"
 require_relative "../commands/nginx"
 
 module Dip
   class CLI
     # See more https://github.com/bibendi/nginx-proxy
-    class Nginx < Thor
+    class Nginx < Base
       desc "up", "Run nginx container"
       method_option :help, aliases: '-h', type: :boolean,
                            desc: 'Display usage information'
@@ -16,7 +17,7 @@ module Dip
                              desc: 'Path to docker socket'
       method_option :net, aliases: '-t', type: :string, default: "frontend",
                           desc: 'Container network name'
-      method_option :publish, aliases: '-p', type: :array, default: "80:80",
+      method_option :publish, aliases: '-p', type: :array, default: ["80:80"],
                               desc: 'Container port(s). For more than one port, separate them by a space'
       method_option :image, aliases: '-i', type: :string, default: "bibendi/nginx-proxy:latest",
                             desc: 'Docker image name'

--- a/lib/dip/cli/ssh.rb
+++ b/lib/dip/cli/ssh.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 require 'thor'
+require_relative "./base"
 require_relative "../commands/ssh"
 
 module Dip
   class CLI
-    class SSH < Thor
+    class SSH < Base
       desc "up", "Run ssh-agent container"
       method_option :help, aliases: '-h', type: :boolean,
                            desc: 'Display usage information'

--- a/lib/dip/commands/compose.rb
+++ b/lib/dip/commands/compose.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'pathname'
+
 require_relative '../command'
 require_relative 'dns'
 
@@ -29,12 +31,14 @@ module Dip
         return unless (files = config[:files])
 
         if files.is_a?(Array)
-          files.each_with_object([]) do |file_name, memo|
-            file_name = ::Dip.env.interpolate(file_name)
-            next unless File.exist?(file_name)
+          files.each_with_object([]) do |file_path, memo|
+            file_path = ::Dip.env.interpolate(file_path)
+            file_path = Pathname.new(file_path)
+            file_path = Dip.config.file_path.parent.join(file_path).expand_path if file_path.relative?
+            next unless file_path.exist?
 
             memo << "--file"
-            memo << file_name
+            memo << file_path.to_s
           end
         end
       end

--- a/lib/dip/commands/console.rb
+++ b/lib/dip/commands/console.rb
@@ -86,7 +86,7 @@ module Dip
         end
 
         def execute
-          if Dip::Config.exist?
+          if Dip.config.exist?
             add_aliases(*Dip.config.interaction.keys) if Dip.config.interaction
             add_aliases("compose", "up", "stop", "down", "provision")
           end

--- a/lib/dip/commands/run.rb
+++ b/lib/dip/commands/run.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'shellwords'
+require_relative '../../../lib/dip/run_vars'
 require_relative '../command'
 require_relative '../interaction_tree'
 require_relative 'compose'

--- a/lib/dip/commands/run.rb
+++ b/lib/dip/commands/run.rb
@@ -9,7 +9,9 @@ require_relative 'compose'
 module Dip
   module Commands
     class Run < Dip::Command
-      def initialize(cmd, *argv)
+      def initialize(cmd, *argv, publish: nil)
+        @publish = publish
+
         @command, @argv = InteractionTree.
                           new(Dip.config.interaction).
                           find(cmd, *argv)&.
@@ -29,13 +31,14 @@ module Dip
 
       private
 
-      attr_reader :command, :argv
+      attr_reader :command, :argv, :publish
 
       def compose_arguments
         compose_argv = command[:compose][:run_options].dup
 
         if command[:compose][:method] == "run"
           compose_argv.concat(run_vars)
+          compose_argv.concat(published_ports)
           compose_argv << "--rm"
         end
 
@@ -55,6 +58,14 @@ module Dip
         return [] unless run_vars
 
         run_vars.map { |k, v| ["-e", "#{k}=#{v}"] }.flatten
+      end
+
+      def published_ports
+        if publish.respond_to?(:each)
+          publish.map { |p| "--publish=#{p}" }
+        else
+          []
+        end
       end
     end
   end

--- a/lib/dip/environment.rb
+++ b/lib/dip/environment.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
+require "pathname"
+
 module Dip
   class Environment
     VAR_REGEX = /\$[\{]?(?<var_name>[a-zA-Z_][a-zA-Z0-9_]*)[\}]?/.freeze
-    SPECIAL_VARS = {"DIP_OS" => :find_dip_os}.freeze
+    SPECIAL_VARS = %i[os work_dir_rel_path].freeze
 
     attr_reader :vars
 
@@ -24,6 +26,10 @@ module Dip
       vars.fetch(name) { ENV[name] }
     end
 
+    def fetch(name)
+      vars.fetch(name) { ENV.fetch(name) { yield } }
+    end
+
     def []=(key, value)
       @vars[key] = value
     end
@@ -32,8 +38,8 @@ module Dip
       value.gsub(VAR_REGEX) do
         var_name = Regexp.last_match[:var_name]
 
-        if SPECIAL_VARS.key?(var_name)
-          self[var_name] || send(SPECIAL_VARS[var_name])
+        if special_vars.key?(var_name)
+          fetch(var_name) { send(special_vars[var_name]) }
         else
           self[var_name]
         end
@@ -44,8 +50,18 @@ module Dip
 
     private
 
-    def find_dip_os
+    def special_vars
+      @special_vars ||= SPECIAL_VARS.each_with_object({}) do |key, memo|
+        memo["DIP_#{key.to_s.upcase}"] = "find_#{key}"
+      end
+    end
+
+    def find_os
       @dip_os ||= Gem::Platform.local.os
+    end
+
+    def find_work_dir_rel_path
+      @find_work_dir_rel_path ||= Pathname.getwd.relative_path_from(Dip.config.file_path.parent).to_s
     end
   end
 end

--- a/lib/dip/version.rb
+++ b/lib/dip/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dip
-  VERSION = "4.2.0"
+  VERSION = "5.0.0.rc1"
 end

--- a/spec/fixtures/cascade/dip.yml
+++ b/spec/fixtures/cascade/dip.yml
@@ -1,0 +1,19 @@
+version: '2'
+
+environment:
+  FOO: bar
+
+compose:
+  files:
+    - docker-compose.yml
+
+interaction:
+  app:
+    service: backend
+    compose:
+      run_options: [publish=80]
+    subcommands:
+      start:
+        command: exec start
+        compose:
+          run_options: [no-deps]

--- a/spec/fixtures/cascade/sub_a/dip.override.yml
+++ b/spec/fixtures/cascade/sub_a/dip.override.yml
@@ -1,0 +1,14 @@
+version: '2'
+
+environment:
+  FOO: baz
+
+compose:
+  files:
+    - docker-compose.local.yml
+
+interaction:
+  app:
+    subcommands:
+      debug:
+        command: exec debug

--- a/spec/lib/dip/commands/run_spec.rb
+++ b/spec/lib/dip/commands/run_spec.rb
@@ -25,6 +25,16 @@ describe Dip::Commands::Run, config: true do
     it { expected_exec("docker-compose", ["run", "--rm", "app"]) }
   end
 
+  context "when publish ports" do
+    before { cli.start "run --publish 3:3 -p 5:5 rails s".shellsplit }
+    it { expected_exec("docker-compose", ["run", "--publish=3:3", "--publish=5:5", "--rm", "app", "rails", "s"]) }
+  end
+
+  context "when publish is part of a command" do
+    before { cli.start "run rails s --publish=3000:3000".shellsplit }
+    it { expected_exec("docker-compose", ["run", "--rm", "app", "rails", "s", "--publish=3000:3000"]) }
+  end
+
   context "when run psql command without db name" do
     before { cli.start "run psql".shellsplit }
     it { expected_exec("docker-compose", ["run", "--rm", "postgres", "psql", "-h", "postgres", "db_dev"]) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,8 +11,9 @@ end
 
 require "pry-byebug"
 require "dip"
+require "dip/run_vars"
 
-Dir["#{__dir__}/support/**/*.rb"].each { |f| require f }
+Dir["#{__dir__}/support/**/*.rb"].sort.each { |f| require f }
 
 RSpec.configure do |config|
   config.filter_run :focus

--- a/spec/support/fixtures_helper.rb
+++ b/spec/support/fixtures_helper.rb
@@ -2,7 +2,7 @@
 
 module FixturesHelper
   def fixture_path(*file_name)
-    File.join(__dir__, "..", "fixtures", *file_name)
+    File.expand_path File.join(__dir__, "..", "fixtures", *file_name)
   end
 end
 


### PR DESCRIPTION
# Context

dip.yml config may be loaded when it's found in the nearest parent directory. The same rule is for dip.override.yml.

# What's inside

<!--
List of features and changes (or highlights) (from the code perspective)
The purpose of this list is to track the progress if it's WIP (use checkboxes)
and to emphasize the critical parts (which you'd like to pay reviewers attention to)
-->
- [x] Added ConfigFinder to traverse parent directories
- [x] Added `$DIP_WORK_DIR_REL_PATH` special environment variable
- [x] Added an ability to add interaction commands coinciding with Ruby keywords
- [x] Added an ability to publish container's ports to the host
- [x] BREAKING: docker-compose config files paths now are relative to dip.yml directory, not to working directory

# Checklist:

- [x] I have added tests
- [x] I have made corresponding changes to the documentation