### PR TITLE
Set min Ruby version to 2.4

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ AllCops:
   Exclude:
     - tmp/**/*
     - vendor/**/*
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
 
 Metrics/BlockLength:
   Exclude:
@@ -55,6 +55,15 @@ Layout/DotPosition:
 
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
+
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: false
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
 
 Metrics/AbcSize:
   Max: 30

--- a/dip.gemspec
+++ b/dip.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 2.3'
+  spec.required_ruby_version = '>= 2.4'
 
   spec.add_dependency "thor", ">= 0.20", "< 1.1"
 
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry-byebug", "~> 3"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "rubocop", "~> 0.59"
+  spec.add_development_dependency "rubocop", "~> 0.81"
   spec.add_development_dependency "simplecov", '~> 0.16'
   spec.add_development_dependency "test-unit", "~> 3"
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   app:
-    image: ruby:2.3
+    image: ruby:2.4-buster
     environment:
       - GEM_HOME=/bundle
       - BUNDLE_PATH=/bundle

--- a/exe/dip
+++ b/exe/dip
@@ -6,7 +6,7 @@ $LOAD_PATH.unshift(lib_path) unless $LOAD_PATH.include?(lib_path)
 
 begin
   require 'pry-byebug' if ENV["DIP_ENV"] == "debug"
-rescue LoadError # rubocop:disable Lint/SuppressedException
+rescue LoadError
   # do nothing
 end
 


### PR DESCRIPTION
# Context

Support of Ruby 2.3 has ended a year ago.

## Related tickets

-

# What's inside

<!--
List of features and changes (or highlights) (from the code perspective)
The purpose of this list is to track the progress if it's WIP (use checkboxes)
and to emphasize the critical parts (which you'd like to pay reviewers attention to)
-->
- [x] Update gemspec
- [x] Upgrade rubocop