### PR TITLE
Add support for UID on ssh command

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ dip VERSION=12352452 rake db:rollback
 Use options `-p, --publish=[]` if you need to additionally publish a container's port(s) to the host unless this behaviour is not configured at dip.yml:
 
 ```sh
-dip run -p 3000:3000 bundle exec rackup config.ru 
+dip run -p 3000:3000 bundle exec rackup config.ru
 ```
 
 ### dip ls
@@ -290,6 +290,21 @@ volumes:
   ssh-data:
     external:
       name: ssh_data
+```
+
+if you want to use non-root user you can specify UID like so:
+
+```
+dip ssh up -u 1000
+```
+
+This especially helpful if you have something like this in your docker-compose.yml:
+
+```
+services:
+  web:
+    user: "1000:1000"
+
 ```
 
 ### dip nginx

--- a/lib/dip/cli/ssh.rb
+++ b/lib/dip/cli/ssh.rb
@@ -16,6 +16,8 @@ module Dip
                              desc: 'Mounted docker volume'
       method_option :interactive, aliases: '-t', type: :boolean, default: true,
                                   desc: 'Run in interactive mode'
+      method_option :user, aliases: '-u', type: :string,
+                                  desc: 'UID for ssh-agent container'
       # Backward compatibility
       method_option :nonteractive, aliases: '-T', type: :boolean,
                                    desc: 'Run in noninteractive mode'
@@ -26,7 +28,8 @@ module Dip
           Dip::Commands::SSH::Up.new(
             key: options.fetch(:key),
             volume: options.fetch(:volume),
-            interactive: options.nonteractive? ? false : options.interactive?
+            interactive: options.nonteractive? ? false : options.interactive?,
+            user: options.user
           ).execute
         end
       end

--- a/lib/dip/cli/ssh.rb
+++ b/lib/dip/cli/ssh.rb
@@ -17,7 +17,7 @@ module Dip
       method_option :interactive, aliases: '-t', type: :boolean, default: true,
                                   desc: 'Run in interactive mode'
       method_option :user, aliases: '-u', type: :string,
-                                  desc: 'UID for ssh-agent container'
+                           desc: 'UID for ssh-agent container'
       # Backward compatibility
       method_option :nonteractive, aliases: '-T', type: :boolean,
                                    desc: 'Run in noninteractive mode'

--- a/lib/dip/commands/ssh.rb
+++ b/lib/dip/commands/ssh.rb
@@ -17,7 +17,10 @@ module Dip
         def execute
           subshell("docker", "volume create --name ssh_data".shellsplit, out: File::NULL, err: File::NULL)
 
-          subshell("docker", "run #{user_args} --detach --volume ssh_data:/ssh --name=ssh-agent whilp/ssh-agent".shellsplit)
+          subshell(
+            "docker",
+            "run #{user_args} --detach --volume ssh_data:/ssh --name=ssh-agent whilp/ssh-agent".shellsplit
+          )
 
           key = Dip.env.interpolate(@key)
           subshell("docker", "run #{container_args} whilp/ssh-agent ssh-add #{key}".shellsplit)

--- a/lib/dip/commands/ssh.rb
+++ b/lib/dip/commands/ssh.rb
@@ -7,22 +7,27 @@ module Dip
   module Commands
     module SSH
       class Up < Dip::Command
-        def initialize(key:, volume:, interactive:)
+        def initialize(key:, volume:, interactive:, user: nil)
           @key = key
           @volume = volume
           @interactive = interactive
+          @user = user
         end
 
         def execute
           subshell("docker", "volume create --name ssh_data".shellsplit, out: File::NULL, err: File::NULL)
 
-          subshell("docker", "run --detach --volume ssh_data:/ssh --name=ssh-agent whilp/ssh-agent".shellsplit)
+          subshell("docker", "run #{user_args} --detach --volume ssh_data:/ssh --name=ssh-agent whilp/ssh-agent".shellsplit)
 
           key = Dip.env.interpolate(@key)
           subshell("docker", "run #{container_args} whilp/ssh-agent ssh-add #{key}".shellsplit)
         end
 
         private
+
+        def user_args
+          "-u #{@user}" if @user
+        end
 
         def container_args
           result = %w(--rm)

--- a/spec/lib/dip/commands/ssh_spec.rb
+++ b/spec/lib/dip/commands/ssh_spec.rb
@@ -31,6 +31,11 @@ describe Dip::Commands::SSH do
       before { cli.start "up --volume /foo/.ssh".shellsplit }
       it { expected_subshell("docker", array_including("--volume", "/foo/.ssh:/foo/.ssh")) }
     end
+
+    context "when option `user` is present" do
+      before { cli.start "up -u 1000".shellsplit }
+      it { expected_subshell("docker", array_including("-u", "1000")) }
+    end
   end
 
   describe Dip::Commands::SSH::Down do


### PR DESCRIPTION
# Context

I had an issue with my docker-compose.yml which specified user key inside it.

Basically something like this:
```
 web:
    build:
      context: .
    environment:
      SSH_AUTH_SOCK: /ssh/auth/sock
    user: "1000:1000"
 ....
```

As an ssh-agent container executed from root user by default application container cannot pick up the data from it which makes any ssh requests to fail. 

I figured that problem by comparing it to another docker-compose that doesn't have such a configuration and was working perfectly.


## Related tickets
None, I just decided to fix my case haha


# What's inside

- New parameter for `dip ssh add` command

With that change end-user will be able to run it like so:
```
dip ssh add -u 1000
```

# Checklist:

- [X] I have added tests
- [X] I have made corresponding changes to the documentation


Let me know if anything requires adjustment.