### PR TITLE
fix: cleans in help command dip down output

### DIFF
--- a/lib/dip/cli.rb
+++ b/lib/dip/cli.rb
@@ -63,7 +63,7 @@ module Dip
       compose("stop", *argv)
     end
 
-    desc "down all services [OPTIONS]", "Run `docker-compose down` command"
+    desc "down [OPTIONS]", "Run `docker-compose down` command"
     def down(*argv)
       compose("down", *argv)
     end


### PR DESCRIPTION
# Context

Running `dip help` shows wrong information about the usage of `dip down`. Led to check the source code in my case.

Current output:
```shell
╰─ dip help
Commands:
  ...
  dip down all services [OPTIONS]  # Run `docker-compose down` command
  dip help [COMMAND]               # Describe available commands or one specific command
  ...
```

Desired output (achieved in this MR):
```shell
Commands:
  ...
  dip down [OPTIONS]  # Run `docker-compose down` command
  dip help [COMMAND]               # Describe available commands or one specific command
  ...
```

# Checklist:
Documentation change on the help command -> none of those were needed to be implemented.
- [x] I have added tests
- [x] I have made corresponding changes to the documentation


# Thanks! 👏