### PR TITLE
feat: adds dip build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ After that we can type commands without `dip` prefix. For example:
 <run-command> *any-args
 compose *any-compose-arg
 up <service>
+build
 down
 provision
 ```

--- a/lib/dip/cli.rb
+++ b/lib/dip/cli.rb
@@ -53,6 +53,11 @@ module Dip
       Dip::Commands::Compose.new(*argv).execute
     end
 
+    desc "build [OPTIONS] SERVICE", "Run `docker-compose build` command"
+    def build(*argv)
+      compose("build", *argv)
+    end
+
     desc "up [OPTIONS] SERVICE", "Run `docker-compose up` command"
     def up(*argv)
       compose("up", *argv)

--- a/lib/dip/commands/console.rb
+++ b/lib/dip/commands/console.rb
@@ -88,7 +88,7 @@ module Dip
         def execute
           if Dip.config.exist?
             add_aliases(*Dip.config.interaction.keys) if Dip.config.interaction
-            add_aliases("compose", "up", "stop", "down", "provision")
+            add_aliases("compose", "up", "stop", "down", "provision", "build")
           end
 
           clear_aliases

--- a/spec/lib/dip/commands/console_spec.rb
+++ b/spec/lib/dip/commands/console_spec.rb
@@ -27,6 +27,8 @@ describe Dip::Commands::Console do
       it { expect { subject }.to output(/unset -f compose/).to_stdout }
       it { expect { subject }.to output(/function up/).to_stdout }
       it { expect { subject }.to output(/unset -f up/).to_stdout }
+      it { expect { subject }.to output(/function build/).to_stdout }
+      it { expect { subject }.to output(/unset -f build/).to_stdout }
       it { expect { subject }.to output(/function stop/).to_stdout }
       it { expect { subject }.to output(/unset -f stop/).to_stdout }
       it { expect { subject }.to output(/function down/).to_stdout }


### PR DESCRIPTION
In order to make easy running some high-level docker-compose commands, `dip compose build` is also now migrated and available at the top level with `dip build`.

# What's inside

## dip console inject

Now it will print also aliases for the dip build command

Manual testing: `bundle exec dip console inject`

```ruby
╰─ bundle exec dip console inject
function bash() { dip bash $@; }

function pry() { dip pry $@; }

function bundle() { dip bundle $@; }

function rspec() { dip rspec $@; }

function rubocop() { dip rubocop $@; }

function compose() { dip compose $@; }

function up() { dip up $@; }

function stop() { dip stop $@; }

function down() { dip down $@; }

function provision() { dip provision $@; }

function build() { dip build $@; }

function dip_clear() {
  unset -f bash
  unset -f pry
  unset -f bundle
  unset -f rspec
  unset -f rubocop
  unset -f compose
  unset -f up
  unset -f stop
  unset -f down
  unset -f provision
  unset -f build
}
```

## dip build

Now it will allow running the dip compose build command from a top-level. Tested in an application and works fine

Manual testing: `bundle exec dip build`

```ruby
╰─ bundle exec dip build
app uses an image, skipping
```

## dip help

Provides documentation about the new `dip build` command.

Manual testing: `bundle exec dip help`

```ruby
╰─ bundle exec dip help
Commands:
  dip build [OPTIONS] SERVICE   # Run `docker-compose build` command
  dip compose CMD [OPTIONS]     # Run docker-compose commands
  dip console                   # Integrate Dip commands into shell (only Z...
  dip console help [COMMAND]    # Describe subcommands or one specific subc...
  dip console inject            # Inject aliases
  dip console start             # Integrate Dip into current shell
  dip dns                       # DNS server for automatic docker container...
  dip dns down                  # Stop dnsdock container
  dip dns help [COMMAND]        # Describe subcommands or one specific subc...
  dip dns ip                    # Get ip address of dnsdock container
  dip dns restart               # Stop and start dnsdock container
  dip dns up                    # Run dnsdock container
  dip down [OPTIONS]            # Run `docker-compose down` command
  dip help [COMMAND]            # Describe available commands or one specif...
  dip ls                        # List available run commands
  dip nginx                     # Nginx reverse proxy server
  dip nginx down                # Stop nginx container
  dip nginx help [COMMAND]      # Describe subcommands or one specific subc...
  dip nginx restart             # Stop and start nginx container
  dip nginx up                  # Run nginx container
  dip provision                 # Execute commands within provision section
  dip run [OPTIONS] CMD [ARGS]  # Run configured command in a docker-compos...
  dip ssh                       # ssh-agent container commands
  dip ssh down                  # Stop ssh-agent container
  dip ssh help [COMMAND]        # Describe subcommands or one specific subc...
  dip ssh restart               # Stop and start ssh-agent container
  dip ssh status                # Show status of ssh-agent container
  dip ssh up                    # Run ssh-agent container
  dip stop [OPTIONS] SERVICE    # Run `docker-compose stop` command
  dip up [OPTIONS] SERVICE      # Run `docker-compose up` command
  dip version                   # dip version

```

# Checklist:

- [ ] I have added tests
- [ ] I have made corresponding changes to the documentation
