### PR TITLE
fix: use recommended message instead of puts in Dangerfile

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -9,9 +9,9 @@ Dir[File.join(__dir__, ".danger/*.rb")].each do |danger_rule_file|
     danger_rule = danger_rule_file.gsub(%r{(^./.danger/|.rb)}, "")
     $stdout.print "- #{danger_rule} "
     eval File.read(danger_rule_file), binding, File.expand_path(danger_rule_file) # rubocop:disable Security/Eval
-    $stdout.puts "✅"
+    $stdout.message "✅"
   rescue StandardError => e
-    $stdout.puts "💥"
+    $stdout.message "💥"
 
     raise "Danger rule :#{danger_rule} failed with exception: #{e.message}\n" \
           "Backtrace: \n#{e.backtrace.join("\n")}"


### PR DESCRIPTION
# Context

Resolves `You used `puts` in your Dangerfile. To print out text to GitHub use `message` instead`
![image](https://user-images.githubusercontent.com/9061249/100546766-568a7e00-3263-11eb-88ff-e90b39252313.png)

# Checklist:

- [x] I have added tests
- [x] I have made corresponding changes to the documentation
