### PR TITLE
Allow to run commands in previous mode without shell interpolations

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,12 @@ interaction:
     default_args: db_dev
     command: psql -h pg -U postgres
 
+  setup_key:
+    description: Copy key
+    service: app
+    command: cp `pwd`/config/key.pem /root/keys/
+    shell: false # you can disable shell interpolations on the host machine and send the command as is
+
   clean_cache:
     description: Delete cache files on the host machine
     command: rm -rf $(pwd)/tmp/cache/*

--- a/lib/dip/commands/compose.rb
+++ b/lib/dip/commands/compose.rb
@@ -10,10 +10,11 @@ module Dip
     class Compose < Dip::Command
       DOCKER_EMBEDDED_DNS = "127.0.0.11"
 
-      attr_reader :argv, :config
+      attr_reader :argv, :config, :shell
 
-      def initialize(*argv)
+      def initialize(*argv, shell: true)
         @argv = argv
+        @shell = shell
         @config = ::Dip.config.compose || {}
       end
 
@@ -22,7 +23,7 @@ module Dip
 
         compose_argv = Array(find_files) + Array(cli_options) + argv
 
-        shell("docker-compose", compose_argv)
+        exec_program("docker-compose", compose_argv, shell: shell)
       end
 
       private

--- a/lib/dip/commands/dns.rb
+++ b/lib/dip/commands/dns.rb
@@ -17,8 +17,8 @@ module Dip
         end
 
         def execute
-          subshell("docker", "network create #{@net}", panic: false, err: File::NULL)
-          subshell("docker", "run #{container_args} #{@image} --domain=#{@domain}")
+          exec_subprocess("docker", "network create #{@net}", panic: false, err: File::NULL)
+          exec_subprocess("docker", "run #{container_args} #{@image} --domain=#{@domain}")
         end
 
         private
@@ -40,8 +40,8 @@ module Dip
         end
 
         def execute
-          subshell("docker", "stop #{@name}", panic: false, out: File::NULL, err: File::NULL)
-          subshell("docker", "rm -v #{@name}", panic: false, out: File::NULL, err: File::NULL)
+          exec_subprocess("docker", "stop #{@name}", panic: false, out: File::NULL, err: File::NULL)
+          exec_subprocess("docker", "rm -v #{@name}", panic: false, out: File::NULL, err: File::NULL)
         end
       end
 
@@ -52,7 +52,7 @@ module Dip
         end
 
         def execute(**options)
-          subshell(
+          exec_subprocess(
             "docker",
             "inspect --format '{{ .NetworkSettings.Networks.#{@net}.IPAddress }}' #{@name}",
             **options

--- a/lib/dip/commands/nginx.rb
+++ b/lib/dip/commands/nginx.rb
@@ -18,8 +18,8 @@ module Dip
         end
 
         def execute
-          subshell("docker", "network create #{@net}", panic: false, err: File::NULL)
-          subshell("docker", "run #{container_args} #{@image}")
+          exec_subprocess("docker", "network create #{@net}", panic: false, err: File::NULL)
+          exec_subprocess("docker", "run #{container_args} #{@image}")
         end
 
         private
@@ -43,8 +43,8 @@ module Dip
         end
 
         def execute
-          subshell("docker", "stop #{@name}", panic: false, out: File::NULL, err: File::NULL)
-          subshell("docker", "rm -v #{@name}", panic: false, out: File::NULL, err: File::NULL)
+          exec_subprocess("docker", "stop #{@name}", panic: false, out: File::NULL, err: File::NULL)
+          exec_subprocess("docker", "rm -v #{@name}", panic: false, out: File::NULL, err: File::NULL)
         end
       end
     end

--- a/lib/dip/commands/provision.rb
+++ b/lib/dip/commands/provision.rb
@@ -7,7 +7,7 @@ module Dip
     class Provision < Dip::Command
       def execute
         Dip.config.provision.each do |command|
-          subshell(command)
+          exec_subprocess(command)
         end
       end
     end

--- a/lib/dip/commands/run.rb
+++ b/lib/dip/commands/run.rb
@@ -23,11 +23,12 @@ module Dip
 
       def execute
         if command[:service].nil?
-          shell(command[:command], get_args)
+          exec_program(command[:command], get_args, shell: command[:shell])
         else
           Dip::Commands::Compose.new(
             command[:compose][:method],
-            *compose_arguments
+            *compose_arguments,
+            shell: command[:shell]
           ).execute
         end
       end
@@ -48,7 +49,11 @@ module Dip
         compose_argv << command.fetch(:service)
 
         unless (cmd = command[:command]).empty?
-          compose_argv << cmd
+          if command[:shell]
+            compose_argv << cmd
+          else
+            compose_argv.concat(cmd.shellsplit)
+          end
         end
 
         compose_argv.concat(get_args)
@@ -75,7 +80,11 @@ module Dip
         if argv.any?
           argv
         elsif !(default_args = command[:default_args]).empty?
-          Array(default_args)
+          if command[:shell]
+            default_args.shellsplit
+          else
+            Array(default_args)
+          end
         else
           []
         end

--- a/lib/dip/commands/ssh.rb
+++ b/lib/dip/commands/ssh.rb
@@ -15,15 +15,15 @@ module Dip
         end
 
         def execute
-          subshell("docker", "volume create --name ssh_data", out: File::NULL, err: File::NULL)
+          exec_subprocess("docker", "volume create --name ssh_data", out: File::NULL, err: File::NULL)
 
-          subshell(
+          exec_subprocess(
             "docker",
             "run #{user_args}--detach --volume ssh_data:/ssh --name=ssh-agent whilp/ssh-agent"
           )
 
           key = Dip.env.interpolate(@key)
-          subshell("docker", "run #{container_args} whilp/ssh-agent ssh-add #{key}")
+          exec_subprocess("docker", "run #{container_args} whilp/ssh-agent ssh-add #{key}")
         end
 
         private
@@ -44,15 +44,15 @@ module Dip
 
       class Down < Dip::Command
         def execute
-          subshell("docker", "stop ssh-agent", panic: false, out: File::NULL, err: File::NULL)
-          subshell("docker", "rm -v ssh-agent", panic: false, out: File::NULL, err: File::NULL)
-          subshell("docker", "volume rm ssh_data", panic: false, out: File::NULL, err: File::NULL)
+          exec_subprocess("docker", "stop ssh-agent", panic: false, out: File::NULL, err: File::NULL)
+          exec_subprocess("docker", "rm -v ssh-agent", panic: false, out: File::NULL, err: File::NULL)
+          exec_subprocess("docker", "volume rm ssh_data", panic: false, out: File::NULL, err: File::NULL)
         end
       end
 
       class Status < Dip::Command
         def execute
-          subshell("docker", "inspect --format '{{.State.Status}}' ssh-agent")
+          exec_subprocess("docker", "inspect --format '{{.State.Status}}' ssh-agent")
         end
       end
     end

--- a/lib/dip/interaction_tree.rb
+++ b/lib/dip/interaction_tree.rb
@@ -60,6 +60,7 @@ module Dip
         description: entry[:description],
         service: entry[:service],
         command: entry[:command].to_s.strip,
+        shell: entry.fetch(:shell, true),
         default_args: entry[:default_args].to_s.strip,
         environment: entry[:environment] || {},
         compose: {

--- a/spec/lib/dip/commands/dns_spec.rb
+++ b/spec/lib/dip/commands/dns_spec.rb
@@ -18,59 +18,59 @@ describe Dip::Commands::DNS do
 
     context "when without arguments" do
       before { cli.start "up".shellsplit }
-      it { expected_subshell("docker", ["network", "create", "frontend"]) }
-      it { expected_subshell("docker", cmd) }
+      it { expected_subprocess("docker", ["network", "create", "frontend"]) }
+      it { expected_subprocess("docker", cmd) }
     end
 
     context "when option `name` is present" do
       let(:name) { "--name foo" }
       before { cli.start "up --name foo".shellsplit }
-      it { expected_subshell("docker", cmd) }
+      it { expected_subprocess("docker", cmd) }
     end
 
     context "when option `socket` is present" do
       let(:volume) { "--volume foo:/var/run/docker.sock:ro" }
       before { cli.start "up --socket foo".shellsplit }
-      it { expected_subshell("docker", cmd) }
+      it { expected_subprocess("docker", cmd) }
     end
 
     context "when option `net` is present" do
       let(:net) { "--net foo" }
       before { cli.start "up --net foo".shellsplit }
-      it { expected_subshell("docker", ["network", "create", "foo"]) }
-      it { expected_subshell("docker", cmd) }
+      it { expected_subprocess("docker", ["network", "create", "foo"]) }
+      it { expected_subprocess("docker", cmd) }
     end
 
     context "when option `publish` is present" do
       let(:port) { "--publish foo" }
       before { cli.start "up --publish foo".shellsplit }
-      it { expected_subshell("docker", cmd) }
+      it { expected_subprocess("docker", cmd) }
     end
 
     context "when option `image` is present" do
       let(:image) { "foo" }
       before { cli.start "up --image foo".shellsplit }
-      it { expected_subshell("docker", cmd) }
+      it { expected_subprocess("docker", cmd) }
     end
 
     context "when option `domain` is present" do
       let(:domain) { "--domain=foo" }
       before { cli.start "up --domain foo".shellsplit }
-      it { expected_subshell("docker", cmd) }
+      it { expected_subprocess("docker", cmd) }
     end
   end
 
   describe Dip::Commands::DNS::Down do
     context "when without arguments" do
       before { cli.start "down".shellsplit }
-      it { expected_subshell("docker", "stop dnsdock") }
-      it { expected_subshell("docker", "rm -v dnsdock") }
+      it { expected_subprocess("docker", "stop dnsdock") }
+      it { expected_subprocess("docker", "rm -v dnsdock") }
     end
 
     context "when option `name` is present" do
       before { cli.start "down --name foo".shellsplit }
-      it { expected_subshell("docker", "stop foo") }
-      it { expected_subshell("docker", "rm -v foo") }
+      it { expected_subprocess("docker", "stop foo") }
+      it { expected_subprocess("docker", "rm -v foo") }
     end
   end
 
@@ -78,18 +78,18 @@ describe Dip::Commands::DNS do
     context "when without arguments" do
       before { cli.start "ip".shellsplit }
       it do
-        expected_subshell("docker", "inspect --format '{{ .NetworkSettings.Networks.frontend.IPAddress }}' dnsdock")
+        expected_subprocess("docker", "inspect --format '{{ .NetworkSettings.Networks.frontend.IPAddress }}' dnsdock")
       end
     end
 
     context "when option `name` is present" do
       before { cli.start "ip --name foo".shellsplit }
-      it { expected_subshell("docker", "inspect --format '{{ .NetworkSettings.Networks.frontend.IPAddress }}' foo") }
+      it { expected_subprocess("docker", "inspect --format '{{ .NetworkSettings.Networks.frontend.IPAddress }}' foo") }
     end
 
     context "when option `net` is present" do
       before { cli.start "ip --net foo".shellsplit }
-      it { expected_subshell("docker", "inspect --format '{{ .NetworkSettings.Networks.foo.IPAddress }}' dnsdock") }
+      it { expected_subprocess("docker", "inspect --format '{{ .NetworkSettings.Networks.foo.IPAddress }}' dnsdock") }
     end
   end
 end

--- a/spec/lib/dip/commands/nginx_spec.rb
+++ b/spec/lib/dip/commands/nginx_spec.rb
@@ -10,9 +10,9 @@ describe Dip::Commands::Nginx do
   describe Dip::Commands::Nginx::Up do
     context "when without arguments" do
       before { cli.start "up".shellsplit }
-      it { expected_subshell("docker", ["network", "create", "frontend"]) }
+      it { expected_subprocess("docker", ["network", "create", "frontend"]) }
       it do
-        expected_subshell(
+        expected_subprocess(
           "docker",
           "run --detach --volume /var/run/docker.sock:/tmp/docker.sock:ro --restart always --publish 80:80 --net frontend --name nginx --label com.dnsdock.alias=docker bibendi/nginx-proxy:latest"
         )
@@ -22,7 +22,7 @@ describe Dip::Commands::Nginx do
     context "when option `name` is present" do
       before { cli.start "up --name foo".shellsplit }
       it {
-        expected_subshell("docker",
+        expected_subprocess("docker",
           "run --detach --volume /var/run/docker.sock:/tmp/docker.sock:ro --restart always --publish 80:80 --net frontend --name foo --label com.dnsdock.alias=docker bibendi/nginx-proxy:latest")
       }
     end
@@ -30,16 +30,16 @@ describe Dip::Commands::Nginx do
     context "when option `socket` is present" do
       before { cli.start "up --socket foo".shellsplit }
       it {
-        expected_subshell("docker",
+        expected_subprocess("docker",
           "run --detach --volume foo:/tmp/docker.sock:ro --restart always --publish 80:80 --net frontend --name nginx --label com.dnsdock.alias=docker bibendi/nginx-proxy:latest")
       }
     end
 
     context "when option `net` is present" do
       before { cli.start "up --net foo".shellsplit }
-      it { expected_subshell("docker", ["network", "create", "foo"]) }
+      it { expected_subprocess("docker", ["network", "create", "foo"]) }
       it {
-        expected_subshell("docker",
+        expected_subprocess("docker",
           "run --detach --volume /var/run/docker.sock:/tmp/docker.sock:ro --restart always --publish 80:80 --net foo --name nginx --label com.dnsdock.alias=docker bibendi/nginx-proxy:latest")
       }
     end
@@ -47,14 +47,14 @@ describe Dip::Commands::Nginx do
     context "when option `publish` is present" do
       before { cli.start "up --publish 80:80".shellsplit }
       it {
-        expected_subshell("docker",
+        expected_subprocess("docker",
           "run --detach --volume /var/run/docker.sock:/tmp/docker.sock:ro --restart always --publish 80:80 --net frontend --name nginx --label com.dnsdock.alias=docker bibendi/nginx-proxy:latest")
       }
 
       context "when more than one port given" do
         before { cli.start "up --publish 80:80 443:443".shellsplit }
         it {
-          expected_subshell("docker",
+          expected_subprocess("docker",
             "run --detach --volume /var/run/docker.sock:/tmp/docker.sock:ro --restart always --publish 80:80 --net frontend --name nginx --label com.dnsdock.alias=docker bibendi/nginx-proxy:latest")
         }
       end
@@ -63,7 +63,7 @@ describe Dip::Commands::Nginx do
     context "when option `image` is present" do
       before { cli.start "up --image foo".shellsplit }
       it {
-        expected_subshell("docker",
+        expected_subprocess("docker",
           "run --detach --volume /var/run/docker.sock:/tmp/docker.sock:ro --restart always --publish 80:80 --net frontend --name nginx --label com.dnsdock.alias=docker foo")
       }
     end
@@ -71,7 +71,7 @@ describe Dip::Commands::Nginx do
     context "when option `domain` is present" do
       before { cli.start "up --domain foo".shellsplit }
       it {
-        expected_subshell("docker",
+        expected_subprocess("docker",
           "run --detach --volume /var/run/docker.sock:/tmp/docker.sock:ro --restart always --publish 80:80 --net frontend --name nginx --label com.dnsdock.alias=foo bibendi/nginx-proxy:latest")
       }
     end
@@ -79,7 +79,7 @@ describe Dip::Commands::Nginx do
     context "when option `certs` is present" do
       before { cli.start "up --certs /home/whoami/certs_storage".shellsplit }
       it {
-        expected_subshell("docker",
+        expected_subprocess("docker",
           "run --detach --volume /var/run/docker.sock:/tmp/docker.sock:ro --volume /home/whoami/certs_storage:/etc/nginx/certs --restart always --publish 80:80 --net frontend --name nginx --label com.dnsdock.alias=docker bibendi/nginx-proxy:latest")
       }
     end
@@ -88,14 +88,14 @@ describe Dip::Commands::Nginx do
   describe Dip::Commands::Nginx::Down do
     context "when without arguments" do
       before { cli.start "down".shellsplit }
-      it { expected_subshell("docker", ["stop", "nginx"]) }
-      it { expected_subshell("docker", ["rm", "-v", "nginx"]) }
+      it { expected_subprocess("docker", ["stop", "nginx"]) }
+      it { expected_subprocess("docker", ["rm", "-v", "nginx"]) }
     end
 
     context "when option `name` is present" do
       before { cli.start "down --name foo".shellsplit }
-      it { expected_subshell("docker", ["stop", "foo"]) }
-      it { expected_subshell("docker", ["rm", "-v", "foo"]) }
+      it { expected_subprocess("docker", ["stop", "foo"]) }
+      it { expected_subprocess("docker", ["rm", "-v", "foo"]) }
     end
   end
 end

--- a/spec/lib/dip/commands/provision_spec.rb
+++ b/spec/lib/dip/commands/provision_spec.rb
@@ -17,6 +17,6 @@ describe Dip::Commands::Provision, config: true do
 
     before { cli.start ["provision"] }
 
-    it { expected_subshell("dip bundle install", []) }
+    it { expected_subprocess("dip bundle install", []) }
   end
 end

--- a/spec/lib/dip/commands/ssh_spec.rb
+++ b/spec/lib/dip/commands/ssh_spec.rb
@@ -13,10 +13,10 @@ describe Dip::Commands::SSH do
 
       before { cli.start "up".shellsplit }
 
-      it { expected_subshell("docker", "volume create --name ssh_data") }
-      it { expected_subshell("docker", "run --detach --volume ssh_data:/ssh --name=ssh-agent whilp/ssh-agent") }
+      it { expected_subprocess("docker", "volume create --name ssh_data") }
+      it { expected_subprocess("docker", "run --detach --volume ssh_data:/ssh --name=ssh-agent whilp/ssh-agent") }
       it {
-        expected_subshell("docker",
+        expected_subprocess("docker",
           "run --rm --volume ssh_data:/ssh --volume /user:/user --interactive --tty whilp/ssh-agent ssh-add /user/.ssh/id_rsa")
       }
     end
@@ -24,7 +24,7 @@ describe Dip::Commands::SSH do
     context "when option `key` is present" do
       before { cli.start "up --key /foo/bar-baz-rsa".shellsplit }
       it {
-        expected_subshell("docker",
+        expected_subprocess("docker",
           "run --rm --volume ssh_data:/ssh --volume /root:/root --interactive --tty whilp/ssh-agent ssh-add /foo/bar-baz-rsa")
       }
     end
@@ -32,28 +32,28 @@ describe Dip::Commands::SSH do
     context "when option `volume` is present" do
       before { cli.start "up --volume /foo/.ssh".shellsplit }
       it {
-        expected_subshell("docker",
+        expected_subprocess("docker",
           "run --rm --volume ssh_data:/ssh --volume /foo/.ssh:/foo/.ssh --interactive --tty whilp/ssh-agent ssh-add /root/.ssh/id_rsa")
       }
     end
 
     context "when option `user` is present" do
       before { cli.start "up -u 1000".shellsplit }
-      it { expected_subshell("docker", "run -u 1000 --detach --volume ssh_data:/ssh --name=ssh-agent whilp/ssh-agent") }
+      it { expected_subprocess("docker", "run -u 1000 --detach --volume ssh_data:/ssh --name=ssh-agent whilp/ssh-agent") }
     end
   end
 
   describe Dip::Commands::SSH::Down do
     before { cli.start "down".shellsplit }
 
-    it { expected_subshell("docker", ["stop", "ssh-agent"]) }
-    it { expected_subshell("docker", ["rm", "-v", "ssh-agent"]) }
-    it { expected_subshell("docker", ["volume", "rm", "ssh_data"]) }
+    it { expected_subprocess("docker", ["stop", "ssh-agent"]) }
+    it { expected_subprocess("docker", ["rm", "-v", "ssh-agent"]) }
+    it { expected_subprocess("docker", ["volume", "rm", "ssh_data"]) }
   end
 
   describe Dip::Commands::SSH::Status do
     before { cli.start "status".shellsplit }
 
-    it { expected_subshell("docker", "inspect --format '{{.State.Status}}' ssh-agent") }
+    it { expected_subprocess("docker", "inspect --format '{{.State.Status}}' ssh-agent") }
   end
 end

--- a/spec/support/shared_contexts/runner.rb
+++ b/spec/support/shared_contexts/runner.rb
@@ -1,23 +1,23 @@
 # frozen_string_literal: true
 
 shared_context "dip command", runner: true do
-  let(:exec_runner) { spy("exec runner") }
-  let(:subshell_runner) { spy("subshell runner") }
+  let(:exec_program_runner) { spy("exec_program runner") }
+  let(:exec_subprocess_runner) { spy("exec_subprocess runner") }
 
   before do
-    stub_const("Dip::Command::ExecRunner", exec_runner)
-    stub_const("Dip::Command::SubshellRunner", subshell_runner)
+    stub_const("Dip::Command::ProgramRunner", exec_program_runner)
+    stub_const("Dip::Command::SubprocessRunner", exec_subprocess_runner)
   end
 end
 
 def expected_exec(cmd, argv, options = kind_of(Hash))
   argv = Array(argv) if argv.is_a?(String)
   cmdline = [cmd, *argv].compact.join(" ").strip
-  expect(exec_runner).to have_received(:call).with(cmdline, options)
+  expect(exec_program_runner).to have_received(:call).with(cmdline, options)
 end
 
-def expected_subshell(cmd, argv, options = kind_of(Hash))
+def expected_subprocess(cmd, argv, options = kind_of(Hash))
   argv = Array(argv) if argv.is_a?(String)
   cmdline = [cmd, *argv].compact.join(" ").strip
-  expect(subshell_runner).to have_received(:call).with(cmdline, options)
+  expect(exec_subprocess_runner).to have_received(:call).with(cmdline, options)
 end


### PR DESCRIPTION
# Context

Sometimes we want to run a command without shell mode.

## Related tickets

https://github.com/bibendi/dip/issues/124

# What's inside

<!--
List of features and changes (or highlights) (from the code perspective)
The purpose of this list is to track the progress if it's WIP (use checkboxes)
and to emphasize the critical parts (which you'd like to pay reviewers attention to)
-->
- [x] Add `shell` option to the config, `true` by default

# Checklist:

- [x] I have added tests
- [x] I have made corresponding changes to the documentation
