### PR TITLE
fix: escape run args in shell mode

### DIFF
--- a/lib/dip/commands/run.rb
+++ b/lib/dip/commands/run.rb
@@ -78,7 +78,11 @@ module Dip
 
       def get_args
         if argv.any?
-          argv
+          if command[:shell]
+            [argv.shelljoin]
+          else
+            Array(default_args)
+          end
         elsif !(default_args = command[:default_args]).empty?
           if command[:shell]
             default_args.shellsplit

--- a/spec/lib/dip/commands/run_spec.rb
+++ b/spec/lib/dip/commands/run_spec.rb
@@ -45,7 +45,7 @@ describe Dip::Commands::Run, config: true do
 
   context "when publish is part of a command" do
     before { cli.start "run rails s --publish=3000:3000".shellsplit }
-    it { expected_exec("docker-compose", ["run", "--rm", "app", "rails", "s", "--publish=3000:3000"]) }
+    it { expected_exec("docker-compose", ["run", "--rm", "app", "rails", "s", "--publish\\=3000:3000"]) }
   end
 
   context "when run psql command without db name" do


### PR DESCRIPTION
# Context

<!--
Short description about the feature and the motivation/issue behind it
-->

We must escape run args in the shell mode.

## Related tickets

Closes #132
