### PR TITLE
Escape compose's config file path

### DIFF
--- a/lib/dip/commands/compose.rb
+++ b/lib/dip/commands/compose.rb
@@ -39,7 +39,7 @@ module Dip
             next unless file_path.exist?
 
             memo << "--file"
-            memo << file_path.to_s
+            memo << Shellwords.escape(file_path.to_s)
           end
         end
       end

--- a/spec/lib/dip/commands/compose_spec.rb
+++ b/spec/lib/dip/commands/compose_spec.rb
@@ -43,6 +43,26 @@ describe Dip::Commands::Compose do
     it { expected_exec("docker-compose", ["--project-directory", "/foo-test", "run"]) }
   end
 
+  context "when compose's config path contains spaces", config: true do
+    let(:config) { {compose: {files: ["file name.yml"]}} }
+    let(:file) { fixture_path("empty", "file name.yml") }
+
+    before do
+      allow_any_instance_of(Pathname).to receive(:exist?) do |obj|
+        case obj.to_s
+        when file
+          true
+        else
+          File.exist?(obj.to_s)
+        end
+      end
+
+      cli.start "compose run".shellsplit
+    end
+
+    it { expected_exec("docker-compose", ["--file", Shellwords.escape(file), "run"]) }
+  end
+
   context "when config contains multiple docker-compose files", config: true do
     context "and some files are not exist" do
       let(:config) { {compose: {files: %w[file1.yml file2.yml file3.yml]}} }


### PR DESCRIPTION
# Context

<!--
Short description about the feature and the motivation/issue behind it
-->

When there is a space in the Compose's config path t, dip fails.


## Related tickets

Close #130 

# What's inside

<!--
List of features and changes (or highlights) (from the code perspective)
The purpose of this list is to track the progress if it's WIP (use checkboxes)
and to emphasize the critical parts (which you'd like to pay reviewers attention to)
-->
- [x] Escape path

# Checklist:

- [x] I have added tests
