### PR TITLE
feat: add ability to override compose command

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,16 @@ Use options `-p, --publish=[]` if you need to additionally publish a container's
 dip run -p 3000:3000 bundle exec rackup config.ru
 ```
 
+You can also override docker compose command by passing `DIP_COMPOSE_COMMAND` if you wish. For example if you want to use [`mutagen-compose`](https://mutagen.io/documentation/orchestration/compose) run `DIP_COMPOSE_COMMAND=mutagen-compose dip run`.
+
+If you want to persist that change you can specify command in `compose` section of dip.yml :
+
+```yml
+compose:
+  command: mutagen-compose
+
+```
+
 ### dip ls
 
 List all available run commands.

--- a/lib/dip/commands/compose.rb
+++ b/lib/dip/commands/compose.rb
@@ -23,7 +23,10 @@ module Dip
 
         compose_argv = Array(find_files) + Array(cli_options) + argv
 
-        if compose_v2?
+        if (override_command = compose_command_override)
+          override_command, *override_args = override_command.split(" ")
+          exec_program(override_command, override_args.concat(compose_argv), shell: shell)
+        elsif compose_v2?
           exec_program("docker", compose_argv.unshift("compose"), shell: shell)
         else
           exec_program("docker-compose", compose_argv, shell: shell)
@@ -79,6 +82,10 @@ module Dip
         end
 
         !!exec_subprocess("docker", "compose version", panic: false, out: File::NULL, err: File::NULL)
+      end
+
+      def compose_command_override
+        Dip.env["DIP_COMPOSE_COMMAND"] || config[:command]
       end
     end
   end

--- a/spec/lib/dip/commands/compose_spec.rb
+++ b/spec/lib/dip/commands/compose_spec.rb
@@ -119,4 +119,49 @@ describe Dip::Commands::Compose do
       it { expected_exec("docker-compose", ["--file", file, "run"]) }
     end
   end
+
+  context "when compose command specified in config", config: true do
+    context "when compose command contains spaces" do
+      let(:config) { {compose: {command: "foo compose"}} }
+
+      before { cli.start "compose run".shellsplit }
+
+      it { expected_exec("foo compose", "run") }
+    end
+
+    context "when compose command does not contain spaces" do
+      let(:config) { {compose: {command: "foo-compose"}} }
+
+      before { cli.start "compose run".shellsplit }
+
+      it { expected_exec("foo-compose", "run") }
+    end
+  end
+
+  context "when DIP_COMPOSE_COMMAND is specified in environment", env: true do
+    context "when DIP_COMPOSE_COMMAND contains spaces" do
+      let(:env) { {"DIP_COMPOSE_COMMAND" => "foo compose"} }
+
+      before { cli.start "compose run".shellsplit }
+
+      it { expected_exec("foo compose", "run") }
+    end
+
+    context "when DIP_COMPOSE_COMMAND does not contain spaces" do
+      let(:env) { {"DIP_COMPOSE_COMMAND" => "foo-compose"} }
+
+      before { cli.start "compose run".shellsplit }
+
+      it { expected_exec("foo-compose", "run") }
+    end
+
+    context "when compose command specified in config", config: true do
+      let(:config) { {compose: {command: "foo compose"}} }
+      let(:env) { {"DIP_COMPOSE_COMMAND" => "bar-compose"} }
+
+      before { cli.start "compose run".shellsplit }
+
+      it { expected_exec("bar-compose", "run") }
+    end
+  end
 end


### PR DESCRIPTION
# Context

Some people who use Mac for development suffer from poor Docker performance on Mac. There is a project called [Mutagen](https://mutagen.io) that makes Mac devs life much easier. It provides it's own wrapper over `docker compose` called [`mutagen-compose`](https://mutagen.io/documentation/orchestration/compose)

To be able to use Mutagen instead of vanilla Docker compose I would like to add ability to override docker compose command.

## Related tickets

-

# What's inside

- [x] Added ability to specify override for docker command in dip config file.
- [x] Added ability to override docker command by passing `DIP_COMPOSE_COMMAND` env variable.

# Checklist:

- [x] I have added tests
- [x] I have made corresponding changes to the documentation
