### PR TITLE
Change the default image for `nginx proxy` to nginxproxy/nginx-proxy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ services:
 
 ### dip nginx
 
-Runs Nginx server container based on [bibendi/nginx-proxy](https://github.com/bibendi/nginx-proxy) image. An application's docker-compose.yml should contain environment variable `VIRTUAL_HOST` and `VIRTUAL_PATH` and connects to external network `frontend`.
+Runs Nginx server container based on [nginxproxy/nginx-proxy](https://github.com/nginx-proxy/nginx-proxy) image. An application's docker-compose.yml should contain environment variable `VIRTUAL_HOST` and `VIRTUAL_PATH` and connects to external network `frontend`.
 
 foo-project/docker-compose.yml
 

--- a/lib/dip/cli/nginx.rb
+++ b/lib/dip/cli/nginx.rb
@@ -6,7 +6,7 @@ require_relative "../commands/nginx"
 
 module Dip
   class CLI
-    # See more https://github.com/bibendi/nginx-proxy
+    # See more https://github.com/nginx-proxy/nginx-proxy
     class Nginx < Base
       desc "up", "Run nginx container"
       method_option :help, aliases: "-h", type: :boolean,
@@ -19,7 +19,7 @@ module Dip
                           desc: "Container network name"
       method_option :publish, aliases: "-p", type: :array, default: ["80:80"],
                               desc: "Container port(s). For more than one port, separate them by a space"
-      method_option :image, aliases: "-i", type: :string, default: "bibendi/nginx-proxy:latest",
+      method_option :image, aliases: "-i", type: :string, default: "nginxproxy/nginx-proxy:latest",
                             desc: "Docker image name"
       method_option :domain, aliases: "-d", type: :string, default: "docker",
                              desc: "Top level domain"

--- a/spec/lib/dip/commands/nginx_spec.rb
+++ b/spec/lib/dip/commands/nginx_spec.rb
@@ -16,7 +16,7 @@ describe Dip::Commands::Nginx do
       it do
         expected_subprocess(
           "docker",
-          "run --detach --volume /var/run/docker.sock:/tmp/docker.sock:ro --restart always --publish 80:80 --net frontend --name nginx --label com.dnsdock.alias=docker bibendi/nginx-proxy:latest"
+          "run --detach --volume /var/run/docker.sock:/tmp/docker.sock:ro --restart always --publish 80:80 --net frontend --name nginx --label com.dnsdock.alias=docker nginxproxy/nginx-proxy:latest"
         )
       end
     end
@@ -26,7 +26,7 @@ describe Dip::Commands::Nginx do
 
       it {
         expected_subprocess("docker",
-          "run --detach --volume /var/run/docker.sock:/tmp/docker.sock:ro --restart always --publish 80:80 --net frontend --name foo --label com.dnsdock.alias=docker bibendi/nginx-proxy:latest")
+          "run --detach --volume /var/run/docker.sock:/tmp/docker.sock:ro --restart always --publish 80:80 --net frontend --name foo --label com.dnsdock.alias=docker nginxproxy/nginx-proxy:latest")
       }
     end
 
@@ -35,7 +35,7 @@ describe Dip::Commands::Nginx do
 
       it {
         expected_subprocess("docker",
-          "run --detach --volume foo:/tmp/docker.sock:ro --restart always --publish 80:80 --net frontend --name nginx --label com.dnsdock.alias=docker bibendi/nginx-proxy:latest")
+          "run --detach --volume foo:/tmp/docker.sock:ro --restart always --publish 80:80 --net frontend --name nginx --label com.dnsdock.alias=docker nginxproxy/nginx-proxy:latest")
       }
     end
 
@@ -46,7 +46,7 @@ describe Dip::Commands::Nginx do
 
       it {
         expected_subprocess("docker",
-          "run --detach --volume /var/run/docker.sock:/tmp/docker.sock:ro --restart always --publish 80:80 --net foo --name nginx --label com.dnsdock.alias=docker bibendi/nginx-proxy:latest")
+          "run --detach --volume /var/run/docker.sock:/tmp/docker.sock:ro --restart always --publish 80:80 --net foo --name nginx --label com.dnsdock.alias=docker nginxproxy/nginx-proxy:latest")
       }
     end
 
@@ -55,7 +55,7 @@ describe Dip::Commands::Nginx do
 
       it {
         expected_subprocess("docker",
-          "run --detach --volume /var/run/docker.sock:/tmp/docker.sock:ro --restart always --publish 80:80 --net frontend --name nginx --label com.dnsdock.alias=docker bibendi/nginx-proxy:latest")
+          "run --detach --volume /var/run/docker.sock:/tmp/docker.sock:ro --restart always --publish 80:80 --net frontend --name nginx --label com.dnsdock.alias=docker nginxproxy/nginx-proxy:latest")
       }
 
       context "when more than one port given" do
@@ -63,7 +63,7 @@ describe Dip::Commands::Nginx do
 
         it {
           expected_subprocess("docker",
-            "run --detach --volume /var/run/docker.sock:/tmp/docker.sock:ro --restart always --publish 80:80 --net frontend --name nginx --label com.dnsdock.alias=docker bibendi/nginx-proxy:latest")
+            "run --detach --volume /var/run/docker.sock:/tmp/docker.sock:ro --restart always --publish 80:80 --net frontend --name nginx --label com.dnsdock.alias=docker nginxproxy/nginx-proxy:latest")
         }
       end
     end
@@ -82,7 +82,7 @@ describe Dip::Commands::Nginx do
 
       it {
         expected_subprocess("docker",
-          "run --detach --volume /var/run/docker.sock:/tmp/docker.sock:ro --restart always --publish 80:80 --net frontend --name nginx --label com.dnsdock.alias=foo bibendi/nginx-proxy:latest")
+          "run --detach --volume /var/run/docker.sock:/tmp/docker.sock:ro --restart always --publish 80:80 --net frontend --name nginx --label com.dnsdock.alias=foo nginxproxy/nginx-proxy:latest")
       }
     end
 
@@ -91,7 +91,7 @@ describe Dip::Commands::Nginx do
 
       it {
         expected_subprocess("docker",
-          "run --detach --volume /var/run/docker.sock:/tmp/docker.sock:ro --volume /home/whoami/certs_storage:/etc/nginx/certs --restart always --publish 80:80 --net frontend --name nginx --label com.dnsdock.alias=docker bibendi/nginx-proxy:latest")
+          "run --detach --volume /var/run/docker.sock:/tmp/docker.sock:ro --volume /home/whoami/certs_storage:/etc/nginx/certs --restart always --publish 80:80 --net frontend --name nginx --label com.dnsdock.alias=docker nginxproxy/nginx-proxy:latest")
       }
     end
   end


### PR DESCRIPTION
# Context

[nginx-proxy/nginx-proxy](https://github.com/nginx-proxy/nginx-proxy) is more actively maintained than [bibendi/nginx-proxy](https://github.com/bibendi/nginx-proxy), so change this to the default.

## Related tickets

Close https://github.com/bibendi/dip/issues/144

# Checklist:

- [x] I have added tests
- [x] I have made corresponding changes to the documentation
