### PR TITLE
README: aAd note about shell collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Dip can be injected into the current shell (ZSH or Bash).
 eval "$(dip console)"
 ```
 
+**IMPORTANT**: Beware of possible collisions with local tools. One particular example is supporting both local and Docker frontend build tools, such as Yarn. If you want some developer to run `yarn` locally and other to use Docker for that, you should either avoid adding the `yarn` command to the `dip.yml` or avoid using the shell integration for hybrid development.
+
 After that we can type commands without `dip` prefix. For example:
 
 ```sh


### PR DESCRIPTION
# Context

We spent a few hours trying to figure out why calling `yarn install` doesn't add anything to the host `node_modules/`.

It turned out, that `eval $(dip console)` was used (since it looks like a recommendation right now).

# Checklist:

- [x] I have made corresponding changes to the documentation
