### PR TITLE
Add command to shutdown all running compose projects

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,12 @@ AllCops:
     - 'tmp/**/*'
   NewCops: enable
 
+RSpec:
+  Language:
+    Expectations:
+      - expected_subprocess
+      - expected_exec
+
 Style/FrozenStringLiteralComment:
   Enabled: true
 

--- a/lib/dip/cli.rb
+++ b/lib/dip/cli.rb
@@ -69,8 +69,17 @@ module Dip
     end
 
     desc "down [OPTIONS]", "Run `docker-compose down` command"
+    method_option :help, aliases: "-h", type: :boolean, desc: "Display usage information"
+    method_option :all, aliases: "-A", type: :boolean, desc: "Shutdown all running docker-compose projects"
     def down(*argv)
-      compose("down", *argv)
+      if options[:help]
+        invoke :help, ["down"]
+      elsif options[:all]
+        require_relative "commands/down_all"
+        Dip::Commands::DownAll.new.execute
+      else
+        compose("down", *argv)
+      end
     end
 
     desc "run [OPTIONS] CMD [ARGS]", "Run configured command in a docker-compose service. `run` prefix may be omitted"

--- a/lib/dip/commands/down_all.rb
+++ b/lib/dip/commands/down_all.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative "../command"
+
+module Dip
+  module Commands
+    class DownAll < Dip::Command
+      def execute
+        exec_subprocess(
+          "docker rm --volumes $(docker stop $(docker ps --filter 'label=com.docker.compose.project' -q))"
+        )
+      end
+    end
+  end
+end

--- a/spec/lib/dip/commands/down_all_spec.rb
+++ b/spec/lib/dip/commands/down_all_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "shellwords"
+require "dip/cli"
+require "dip/commands/down_all"
+
+describe Dip::Commands::DownAll do
+  let(:cli) { Dip::CLI }
+
+  before { cli.start "down -A".shellsplit }
+
+  it "runs a valid command" do
+    expected_subprocess(
+      "docker rm --volumes $(docker stop $(docker ps --filter 'label=com.docker.compose.project' -q))",
+      []
+    )
+  end
+end


### PR DESCRIPTION
# Context

I work with many docker compose projects simultaneously, so I want to shutdown them all at the end of the working day to save CPU and RAM resources for other things.

## Related tickets

-

# What's inside

<!--
List of features and changes (or highlights) (from the code perspective)
The purpose of this list is to track the progress if it's WIP (use checkboxes)
and to emphasize the critical parts (which you'd like to pay reviewers attention to)
-->
- [x] add a command `dip down -A`

# Checklist:

- [x] I have added tests
