### PR TITLE
Add kubectl support

### DIFF
--- a/lib/dip/cli.rb
+++ b/lib/dip/cli.rb
@@ -32,7 +32,7 @@ module Dip
       end
     end
 
-    stop_on_unknown_option! :run
+    stop_on_unknown_option! :run, :ktl
 
     desc "version", "dip version"
     def version
@@ -82,7 +82,13 @@ module Dip
       end
     end
 
-    desc "run [OPTIONS] CMD [ARGS]", "Run configured command in a docker-compose service. `run` prefix may be omitted"
+    desc "ktl CMD [OPTIONS]", "Run kubectl commands"
+    def ktl(*argv)
+      require_relative "commands/kubectl"
+      Dip::Commands::Kubectl.new(*argv).execute
+    end
+
+    desc "run [OPTIONS] CMD [ARGS]", "Run configured command (`run` prefix may be omitted)"
     method_option :publish, aliases: "-p", type: :string, repeatable: true,
       desc: "Publish a container's port(s) to the host"
     method_option :help, aliases: "-h", type: :boolean, desc: "Display usage information"
@@ -91,7 +97,11 @@ module Dip
         invoke :help, ["run"]
       else
         require_relative "commands/run"
-        Dip::Commands::Run.new(*argv, publish: options[:publish]).execute
+
+        Dip::Commands::Run.new(
+          *argv,
+          **options.to_h.transform_keys!(&:to_sym)
+        ).execute
       end
     end
 

--- a/lib/dip/commands/kubectl.rb
+++ b/lib/dip/commands/kubectl.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require_relative "../command"
+
+module Dip
+  module Commands
+    class Kubectl < Dip::Command
+      attr_reader :argv, :config
+
+      def initialize(*argv)
+        @argv = argv
+        @config = ::Dip.config.kubectl || {}
+      end
+
+      def execute
+        k_argv = cli_options + argv
+
+        exec_program("kubectl", k_argv)
+      end
+
+      private
+
+      def cli_options
+        %i[namespace].flat_map do |name|
+          next unless (value = config[name])
+          next unless value.is_a?(String)
+
+          value = ::Dip.env.interpolate(value).delete_suffix("-")
+          ["--#{name.to_s.tr("_", "-")}", value]
+        end.compact
+      end
+    end
+  end
+end

--- a/lib/dip/commands/run.rb
+++ b/lib/dip/commands/run.rb
@@ -4,13 +4,17 @@ require "shellwords"
 require_relative "../../../lib/dip/run_vars"
 require_relative "../command"
 require_relative "../interaction_tree"
-require_relative "compose"
+require_relative "runners/local_runner"
+require_relative "runners/docker_compose_runner"
+require_relative "runners/kubectl_runner"
+
+require_relative "kubectl"
 
 module Dip
   module Commands
     class Run < Dip::Command
-      def initialize(cmd, *argv, publish: nil)
-        @publish = publish
+      def initialize(cmd, *argv, **options)
+        @options = options
 
         @command, @argv = InteractionTree
           .new(Dip.config.interaction)
@@ -22,75 +26,25 @@ module Dip
       end
 
       def execute
-        if command[:service].nil?
-          exec_program(command[:command], get_args, shell: command[:shell])
-        else
-          Dip::Commands::Compose.new(
-            command[:compose][:method],
-            *compose_arguments,
-            shell: command[:shell]
-          ).execute
-        end
+        lookup_runner
+          .new(command, argv, **options)
+          .execute
       end
 
       private
 
-      attr_reader :command, :argv, :publish
+      attr_reader :command, :argv, :options
 
-      def compose_arguments
-        compose_argv = command[:compose][:run_options].dup
-
-        if command[:compose][:method] == "run"
-          compose_argv.concat(run_vars)
-          compose_argv.concat(published_ports)
-          compose_argv << "--rm"
-        end
-
-        compose_argv << command.fetch(:service)
-
-        unless (cmd = command[:command]).empty?
-          if command[:shell]
-            compose_argv << cmd
-          else
-            compose_argv.concat(cmd.shellsplit)
-          end
-        end
-
-        compose_argv.concat(get_args)
-
-        compose_argv
-      end
-
-      def run_vars
-        run_vars = Dip::RunVars.env
-        return [] unless run_vars
-
-        run_vars.map { |k, v| ["-e", "#{k}=#{Shellwords.escape(v)}"] }.flatten
-      end
-
-      def published_ports
-        if publish.respond_to?(:each)
-          publish.map { |p| "--publish=#{p}" }
+      def lookup_runner
+        if (runner = command[:runner])
+          camelized_runner = runner.split("_").collect(&:capitalize).join
+          Runners.const_get("#{camelized_runner}Runner")
+        elsif command[:service]
+          Runners::DockerComposeRunner
+        elsif command[:pod]
+          Runners::KubectlRunner
         else
-          []
-        end
-      end
-
-      def get_args
-        if argv.any?
-          if command[:shell]
-            [argv.shelljoin]
-          else
-            Array(argv)
-          end
-        elsif !(default_args = command[:default_args]).empty?
-          if command[:shell]
-            default_args.shellsplit
-          else
-            Array(default_args)
-          end
-        else
-          []
+          Runners::LocalRunner
         end
       end
     end

--- a/lib/dip/commands/runners/base.rb
+++ b/lib/dip/commands/runners/base.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Dip
+  module Commands
+    module Runners
+      class Base
+        def initialize(command, argv, **options)
+          @command = command
+          @argv = argv
+          @options = options
+        end
+
+        def execute
+          raise NotImplementedError
+        end
+
+        private
+
+        attr_reader :command, :argv, :options
+
+        def command_args
+          if argv.any?
+            if command[:shell]
+              [argv.shelljoin]
+            else
+              Array(argv)
+            end
+          elsif !(default_args = command[:default_args]).empty?
+            if command[:shell]
+              default_args.shellsplit
+            else
+              Array(default_args)
+            end
+          else
+            []
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dip/commands/runners/docker_compose_runner.rb
+++ b/lib/dip/commands/runners/docker_compose_runner.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require_relative "base"
+require_relative "../compose"
+
+module Dip
+  module Commands
+    module Runners
+      class DockerComposeRunner < Base
+        def execute
+          Commands::Compose.new(
+            command[:compose][:method],
+            *compose_arguments,
+            shell: command[:shell]
+          ).execute
+        end
+
+        private
+
+        def compose_arguments
+          compose_argv = command[:compose][:run_options].dup
+
+          if command[:compose][:method] == "run"
+            compose_argv.concat(run_vars)
+            compose_argv.concat(published_ports)
+            compose_argv << "--rm"
+          end
+
+          compose_argv << command.fetch(:service)
+
+          unless (cmd = command[:command]).empty?
+            if command[:shell]
+              compose_argv << cmd
+            else
+              compose_argv.concat(cmd.shellsplit)
+            end
+          end
+
+          compose_argv.concat(command_args)
+
+          compose_argv
+        end
+
+        def run_vars
+          run_vars = Dip::RunVars.env
+          return [] unless run_vars
+
+          run_vars.map { |k, v| ["-e", "#{k}=#{Shellwords.escape(v)}"] }.flatten
+        end
+
+        def published_ports
+          publish = options[:publish]
+
+          if publish.respond_to?(:each)
+            publish.map { |p| "--publish=#{p}" }
+          else
+            []
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dip/commands/runners/kubectl_runner.rb
+++ b/lib/dip/commands/runners/kubectl_runner.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require_relative "base"
+require_relative "../kubectl"
+
+module Dip
+  module Commands
+    module Runners
+      class KubectlRunner < Base
+        def execute
+          Commands::Kubectl.new(*kubectl_arguments).execute
+        end
+
+        private
+
+        def kubectl_arguments
+          argv = ["exec", "--tty", "--stdin"]
+
+          pod, container = command.fetch(:pod).split(":")
+          argv.push("--container", container) unless container.nil?
+          argv.push(pod, "--")
+
+          unless (entrypoint = command[:entrypoint]).nil?
+            argv << entrypoint
+          end
+          argv << command.fetch(:command)
+          argv.concat(command_args)
+
+          argv
+        end
+      end
+    end
+  end
+end

--- a/lib/dip/commands/runners/local_runner.rb
+++ b/lib/dip/commands/runners/local_runner.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative "base"
+require_relative "../../command"
+
+module Dip
+  module Commands
+    module Runners
+      class LocalRunner < Base
+        def execute
+          Dip::Command.exec_program(
+            command[:command],
+            command_args,
+            shell: command[:shell]
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/dip/config.rb
+++ b/lib/dip/config.rb
@@ -16,6 +16,7 @@ module Dip
     CONFIG_DEFAULTS = {
       environment: {},
       compose: {},
+      kubectl: {},
       interation: {},
       provision: []
     }.freeze
@@ -94,7 +95,7 @@ module Dip
       config
     end
 
-    %i[environment compose interaction provision].each do |key|
+    %i[environment compose kubectl interaction provision].each do |key|
       define_method(key) do
         config[key] || (raise config_missing_error(key))
       end

--- a/lib/dip/interaction_tree.rb
+++ b/lib/dip/interaction_tree.rb
@@ -58,7 +58,10 @@ module Dip
     def build_command(entry)
       {
         description: entry[:description],
+        runner: entry[:runner],
         service: entry[:service],
+        pod: entry[:pod],
+        entrypoint: entry[:entrypoint],
         command: entry[:command].to_s.strip,
         shell: entry.fetch(:shell, true),
         default_args: entry[:default_args].to_s.strip,

--- a/spec/lib/dip/commands/kubectl_spec.rb
+++ b/spec/lib/dip/commands/kubectl_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "shellwords"
+require "dip/cli"
+require "dip/commands/kubectl"
+
+describe Dip::Commands::Kubectl do
+  let(:cli) { Dip::CLI }
+
+  context "when execute without extra arguments" do
+    before { cli.start "ktl get pods".shellsplit }
+
+    it { expected_exec("kubectl", ["get", "pods"]) }
+  end
+
+  context "when execute with arguments" do
+    before { cli.start "ktl exec app -- ls -l".shellsplit }
+
+    it { expected_exec("kubectl", ["exec", "app", "--", "ls", "-l"]) }
+  end
+
+  context "when config contains namespace", config: true do
+    let(:config) { {kubectl: {namespace: "rocket"}} }
+
+    before { cli.start "ktl get pods".shellsplit }
+
+    it { expected_exec("kubectl", ["--namespace", "rocket", "get", "pods"]) }
+  end
+
+  context "when config contains namespace with env vars", config: true, env: true do
+    let(:config) { {kubectl: {namespace: "rocket-${STAGE}"}} }
+    let(:env) { {"STAGE" => "test"} }
+
+    before { cli.start "ktl get pods".shellsplit }
+
+    it { expected_exec("kubectl", ["--namespace", "rocket-test", "get", "pods"]) }
+  end
+
+  context "when config contains namespace with empty env vars", config: true, env: true do
+    let(:config) { {kubectl: {namespace: "rocket-${STAGE}"}} }
+    let(:env) { {"STAGE" => ""} }
+
+    before { cli.start "ktl get pods".shellsplit }
+
+    it { expected_exec("kubectl", ["--namespace", "rocket", "get", "pods"]) }
+  end
+end

--- a/spec/lib/dip/commands/runners/docker_compose_runner_spec.rb
+++ b/spec/lib/dip/commands/runners/docker_compose_runner_spec.rb
@@ -4,32 +4,17 @@ require "shellwords"
 require "dip/cli"
 require "dip/commands/run"
 
-describe Dip::Commands::Run, config: true do
+describe Dip::Commands::Runners::DockerComposeRunner, config: true do
   let(:config) { {interaction: commands} }
   let(:commands) do
     {
       bash: {service: "app"},
       bash_shell: {service: "app", command: "bash", shell: false},
-      rails: {service: "app", command: "rails"},
-      psql: {service: "postgres", command: "psql -h postgres", default_args: "db_dev"},
-      setup: {command: "./bin/setup", default_args: "all"}
+      rails: {runner: "docker_compose", service: "app", command: "rails"},
+      psql: {service: "postgres", command: "psql -h postgres", default_args: "db_dev"}
     }
   end
   let(:cli) { Dip::CLI }
-
-  context "when run command on host" do
-    context "when using default args" do
-      before { cli.start "run setup".shellsplit }
-
-      it { expected_exec("./bin/setup", ["all"]) }
-    end
-
-    context "when args are provided" do
-      before { cli.start "run setup db".shellsplit }
-
-      it { expected_exec("./bin/setup", ["db"]) }
-    end
-  end
 
   context "when run bash command" do
     before { cli.start "run bash".shellsplit }

--- a/spec/lib/dip/commands/runners/kubectl_runner_spec.rb
+++ b/spec/lib/dip/commands/runners/kubectl_runner_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "shellwords"
+require "dip/cli"
+require "dip/commands/run"
+
+describe Dip::Commands::Runners::KubectlRunner, config: true do
+  let(:config) { {interaction: commands} }
+  let(:commands) do
+    {
+      bash: {pod: "app", command: "/usr/bin/bash"},
+      bundle: {runner: "kubectl", pod: "app:cont", command: "bundle"},
+      rails: {
+        pod: "app",
+        entrypoint: "/entrypoint",
+        command: "rails"
+      },
+      psql: {pod: "app", command: "psql -h postgres", default_args: "db_dev"}
+    }
+  end
+  let(:cli) { Dip::CLI }
+
+  context "when run bash command" do
+    before { cli.start "run bash".shellsplit }
+
+    it { expected_exec("kubectl", ["exec", "--tty", "--stdin", "app", "--", "/usr/bin/bash"]) }
+  end
+
+  context "when run shorthanded bash command" do
+    before { cli.start ["bash"] }
+
+    it { expected_exec("kubectl", ["exec", "--tty", "--stdin", "app", "--", "/usr/bin/bash"]) }
+  end
+
+  context "when run psql command without db name" do
+    before { cli.start "run psql".shellsplit }
+
+    it { expected_exec("kubectl", ["exec", "--tty", "--stdin", "app", "--", "psql", "-h", "postgres", "db_dev"]) }
+  end
+
+  context "when run psql command with db name" do
+    before { cli.start "run psql db_test".shellsplit }
+
+    it { expected_exec("kubectl", ["exec", "--tty", "--stdin", "app", "--", "psql", "-h", "postgres", "db_test"]) }
+  end
+
+  context "when run rails command" do
+    before { cli.start "run rails".shellsplit }
+
+    it { expected_exec("kubectl", ["exec", "--tty", "--stdin", "app", "--", "/entrypoint", "rails"]) }
+  end
+
+  context "when run rails command with subcommand" do
+    before { cli.start "run rails console".shellsplit }
+
+    it { expected_exec("kubectl", ["exec", "--tty", "--stdin", "app", "--", "/entrypoint", "rails", "console"]) }
+  end
+
+  context "when run rails command with arguments" do
+    before { cli.start "run rails g migration add_index --force".shellsplit }
+
+    it { expected_exec("kubectl", ["exec", "--tty", "--stdin", "app", "--", "/entrypoint", "rails", "g", "migration", "add_index", "--force"]) }
+  end
+
+  context "when run with specific container" do
+    before { cli.start "bundle".shellsplit }
+
+    it { expected_exec("kubectl", ["exec", "--tty", "--stdin", "--container", "cont", "app", "--", "bundle"]) }
+  end
+
+  context "when config with namespace" do
+    let(:config) do
+      {
+        environment: {
+          "STAGE" => ""
+        },
+        kubectl: {
+          namespace: "appspace-${STAGE}"
+        },
+        interaction: commands
+      }
+    end
+
+    before { cli.start "run rails server".shellsplit }
+
+    it { expected_exec("kubectl", ["--namespace", "appspace", "exec", "--tty", "--stdin", "app", "--", "/entrypoint", "rails", "server"]) }
+  end
+end

--- a/spec/lib/dip/commands/runners/local_runner_spec.rb
+++ b/spec/lib/dip/commands/runners/local_runner_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "shellwords"
+require "dip/cli"
+require "dip/commands/run"
+
+describe Dip::Commands::Runners::LocalRunner, config: true do
+  let(:config) { {interaction: commands} }
+  let(:commands) do
+    {
+      setup: {command: "./bin/setup", default_args: "all"}
+    }
+  end
+  let(:cli) { Dip::CLI }
+
+  context "when using default args" do
+    before { cli.start "run setup".shellsplit }
+
+    it { expected_exec("./bin/setup", ["all"]) }
+  end
+
+  context "when args are provided" do
+    before { cli.start "run setup db".shellsplit }
+
+    it { expected_exec("./bin/setup", ["db"]) }
+  end
+end


### PR DESCRIPTION
# Context

<!--
Short description about the feature and the motivation/issue behind it
-->
We want to run kubectl commands inside Dip.

## Related tickets

-

# What's inside

<!--
List of features and changes (or highlights) (from the code perspective)
The purpose of this list is to track the progress if it's WIP (use checkboxes)
and to emphasize the critical parts (which you'd like to pay reviewers attention to)
-->
- [x] Refactor `run` command. Implement Runners
- [x] Add KubectlRunner
- [x] Add `pod`, `entrypoint` options to command config
- [x] Add `namespace` to new `kubeclt` config group
- [x] Add `dip ktl` command

# Checklist:

- [x] I have added tests
- [x] I have made corresponding changes to the documentation
