### PR TITLE
add docker compose profiles support

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,12 @@ interaction:
         compose:
           run_options: [service-ports, use-aliases]
 
+  stack:
+    description: Run full stack (server, workers, etc.)
+    runner: docker_compose
+    compose:
+      profiles: [web, workers]
+
   sidekiq:
     description: Run sidekiq in background
     service: worker

--- a/lib/dip/cli.rb
+++ b/lib/dip/cli.rb
@@ -78,7 +78,7 @@ module Dip
         require_relative "commands/down_all"
         Dip::Commands::DownAll.new.execute
       else
-        compose("down", *argv)
+        compose("down", *argv.push("--remove-orphans"))
       end
     end
 

--- a/lib/dip/commands/compose.rb
+++ b/lib/dip/commands/compose.rb
@@ -13,7 +13,7 @@ module Dip
       attr_reader :argv, :config, :shell
 
       def initialize(*argv, shell: true)
-        @argv = argv
+        @argv = argv.compact
         @shell = shell
         @config = ::Dip.config.compose || {}
       end

--- a/lib/dip/interaction_tree.rb
+++ b/lib/dip/interaction_tree.rb
@@ -68,6 +68,7 @@ module Dip
         environment: entry[:environment] || {},
         compose: {
           method: entry.dig(:compose, :method) || entry[:compose_method] || "run",
+          profiles: Array(entry.dig(:compose, :profiles)),
           run_options: compose_run_options(entry.dig(:compose, :run_options) || entry[:compose_run_options])
         }
       }

--- a/spec/lib/dip/commands/runners/docker_compose_runner_spec.rb
+++ b/spec/lib/dip/commands/runners/docker_compose_runner_spec.rb
@@ -136,6 +136,22 @@ describe Dip::Commands::Runners::DockerComposeRunner, config: true do
     it { expected_exec("docker-compose", ["run", "--rm", "app", "rspec"], env: hash_including("RAILS_ENV" => "test")) }
   end
 
+  context "when config with profiles" do
+    let(:commands) do
+      {
+        stack: {
+          runner: "docker_compose",
+          compose_run_options: ["foo", "-bar", "--baz=qux"],
+          compose: {profiles: ["foo", "bar"]}
+        }
+      }
+    end
+
+    before { cli.start "run stack".shellsplit }
+
+    it { expected_exec("docker-compose", ["--profile", "foo", "--profile", "bar", "up"]) }
+  end
+
   context "when config with subcommands" do
     let(:commands) { {rails: {service: "app", command: "rails", subcommands: subcommands}} }
     let(:subcommands) { {s: {command: "rails server"}} }
@@ -187,6 +203,19 @@ describe Dip::Commands::Runners::DockerComposeRunner, config: true do
           ["run", "--rm", "app", "rake", "db:drop", "db:tests:prepare", "db:migrate"],
           env: hash_including("RAILS_ENV" => "test"))
       end
+    end
+
+    context "when config with profiles" do
+      let(:subcommands) do
+        {all: {
+          compose_run_options: ["foo", "-bar", "--baz=qux"],
+          compose: {profiles: ["foo", "bar"]}}
+        }
+      end
+
+      before { cli.start "run rails all".shellsplit }
+
+      it { expected_exec("docker-compose", ["--profile", "foo", "--profile", "bar", "up"]) }
     end
   end
 end


### PR DESCRIPTION
```
  full:
    description: Run all services
    runner: docker_compose
    compose:
      profiles: [workers, backend]
```
Config like this will run `docker compose --profile workers --profile backend up` command. Run options and service configs are ignored even if provided. Can also be a part of subcommand:
```
  rails:
    description: Run Rails commands
    service: backend
    command: bundle exec rails
    subcommands:
      all:
        description: Run Rails server, Sidekiq and RabbitMQ workers
        compose:
          profiles: [workers, backend]
```

There is an issue with Ctrl+C command in this case:
```
...
Aborting on container exit...
[+] Running 9/9
 ✔ Container app-realtime-1   Stopped    10.4s
 ✔ Container app              Stopped     0.3s
 ✔ Container app-rabbitmq-1   Stopped     1.3s
 ✔ Container app-sidekiq-1    Stopped    10.3s
 ✔ Container app-faye-1       Stopped     0.2s
 ✔ Container app-mongodb-1    Stopped     0.2s
 ✔ Container app-memcached-1  Stopped     0.2s
 ✔ Container app-database-1   Stopped     1.9s
 ✔ Container app-redis-1      Stopped     0.1s
canceled

$ docker container ls --all
CONTAINER ID   IMAGE                           COMMAND                  CREATED              STATUS                   NAMES
67475bb645b3   app-dev:latest             "/app/.dockerdev/ent…"   About a minute ago   Exited (137) 24 seconds ago   app-realtime-1
47ab521ae5c7   app-dev:latest             "/app/.dockerdev/ent…"   About a minute ago   Exited (137) 24 seconds ago   app-sidekiq-1
22e7a9bd7faf   app-dev:latest             "/app/.dockerdev/ent…"   About a minute ago   Exited (1) 34 seconds ago     app
c96e42e35f18   srv-faye:latest            "docker-entrypoint.s…"   About a minute ago   Exited (0) 24 seconds ago     app-faye-1
1816e2dfac59   rabbitmq:3.9.7-management  "docker-entrypoint.s…"   About a minute ago   Exited (0) 33 seconds ago     app-rabbitmq-1
6fc9360684fc   memcached:1.5.22-alpine    "docker-entrypoint.s…"   About a minute ago   Exited (0) 24 seconds ago     app-memcached-1
aa9bde5cf18e   redis:5-bullseye           "docker-entrypoint.s…"   About a minute ago   Exited (0) 24 seconds ago     app-redis-1
677beebb60a2   mariadb:10.2               "docker-entrypoint.s…"   About a minute ago   Exited (0) 22 seconds ago     app-database-1
014529fd2f5e   mongo:4.4.8                "docker-entrypoint.s…"   About a minute ago   Exited (0) 24 seconds ago     app-mongodb-1
```
I.e. on Ctrl+C, containers are not removed. So, the next `dip up` command may raise an error about missing network. To resolve, `dip down` can be used. Also, `dip down` was slightly updated to remove orphan containers by adding `--remove-orphans` flag.
