### PR TITLE
bump up dip minimum version to 7.7 in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Also, you can check out examples at the top.
 
 ```yml
 # Required minimum dip version
-version: '7.5'
+version: '7.7'
 
 environment:
   COMPOSE_EXT: development


### PR DESCRIPTION
change dip version from 7.5 to 7.7 in the example

# Context
example config contains docker compose profile feature which was introduced in 7.6

## Related tickets

- [pull/162](https://github.com/bibendi/dip/pull/162)

# What's inside

update to README.md

# Checklist:

- [ ] I have added tests
- [x] I have made corresponding changes to the documentation
