### PR TITLE
`DIP_CURRENT_USER` added

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,36 @@ returned is `/app/sub-project-dir`.
 
 #### $DIP_CURRENT_USER
 
-Exposes the current user ID (UID). It is useful when you need to run a container with the same user as the host machine.
+Exposes the current user ID (UID). It is useful when you need to run a container with the same user as the host machine. For example:
+
+```yml
+# dip.yml (1)
+environment:
+  UID: ${DIP_CURRENT_USER}
+```
+
+```yml
+# docker-compose.yml (2)
+services:
+  app:
+    build:
+      context: ./
+      dockerfile: Dockerfile
+      target: development
+      args:
+        UID: ${UID:-1000}
+```
+
+```dockerfile
+# Dockerfile (3)
+FROM ruby
+ARG UID
+RUN useradd --uid ${UID} --shell /bin/bash app_user
+USER app_user
+```
+
+The user created in the container will have the same UID as the host machine.
+
 
 ### dip run
 

--- a/README.md
+++ b/README.md
@@ -222,6 +222,10 @@ dip run bash -c pwd
 
 returned is `/app/sub-project-dir`.
 
+#### $DIP_CURRENT_USER
+
+Exposes the current user ID (UID). It is useful when you need to run a container with the same user as the host machine.
+
 ### dip run
 
 Run commands defined within the `interaction` section of dip.yml

--- a/README.md
+++ b/README.md
@@ -236,23 +236,11 @@ environment:
 # docker-compose.yml (2)
 services:
   app:
-    build:
-      context: ./
-      dockerfile: Dockerfile
-      target: development
-      args:
-        UID: ${UID:-1000}
+    image: ruby
+    user: ${UID:-1000}
 ```
 
-```dockerfile
-# Dockerfile (3)
-FROM ruby
-ARG UID
-RUN useradd --uid ${UID} --shell /bin/bash app_user
-USER app_user
-```
-
-The user created in the container will have the same UID as the host machine.
+The container will run using the same user ID as your host machine.
 
 
 ### dip run

--- a/lib/dip/environment.rb
+++ b/lib/dip/environment.rb
@@ -5,7 +5,7 @@ require "pathname"
 module Dip
   class Environment
     VAR_REGEX = /\$\{?(?<var_name>[a-zA-Z_][a-zA-Z0-9_]*)\}?/.freeze
-    SPECIAL_VARS = %i[os work_dir_rel_path].freeze
+    SPECIAL_VARS = %i[os work_dir_rel_path current_user].freeze
 
     attr_reader :vars
 
@@ -62,6 +62,10 @@ module Dip
 
     def find_work_dir_rel_path
       @find_work_dir_rel_path ||= Pathname.getwd.relative_path_from(Dip.config.file_path.parent).to_s
+    end
+
+    def find_current_user
+      @find_current_user ||= Process.uid
     end
   end
 end


### PR DESCRIPTION
# Context

Adds a `DIP_CURRENT_USER` variable to the special variables that dip exposes.

## Related tickets

- #153
- #167

# Checklist:

- [ ] I have added tests
- [x] I have made corresponding changes to the documentation

I haven't added tests, but I couldn't find any tests for the existing special variables.

This is my dip config and terminal command showing it working.

```yml
# Required minimum dip version
version: '7.1'

compose:
  files:
    - docker-compose.yml
    - docker-compose.$USER.yml

environment:
  USER_ID: ${DIP_CURRENT_USER}

interaction:
  bash:
    description: Open the Bash shell in app's container
    service: app
    command: bash
    compose_run_options: [no-deps]
```

![CleanShot 2024-02-26 at 21 06 50@2x](https://github.com/bibendi/dip/assets/880387/2386d20c-6a23-4eb6-a24b-a8b3ca8a19e9)
