### PR TITLE
Modules section for dip

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,92 @@ services:
 
 The container will run using the same user ID as your host machine.
 
+### Modules
+
+Modules are defined as array in `modules` section of dip.yml, modules are stored in `.dip` subdirectory of dip.yml directory.
+
+The main purpose of modules is to improve maintainability for a group of projects.
+Imagine having multiple gems which are managed with dip, each of them has the same commands, so to change one command in dip you need to update all gems individualy.
+
+With `modules` you can define a group of modules for dip.
+
+For example having setup as this:
+
+```yml
+# ./dip.yml
+modules:
+ - sasts
+ - rails
+
+...
+```
+
+```yml
+# ./.dip/sasts.yml
+interaction:
+  brakeman:
+    description: Check brakeman sast
+    command: docker run ...
+```
+
+```yml
+# ./.dip/rails.yml
+interaction:
+  annotate:
+    description: Run annotate command
+    service: backend
+    command: bundle exec annotate
+```
+
+Will be expanded to:
+
+```yml
+# resultant configuration
+interaction:
+  brakeman:
+    description: Check brakeman sast
+    command: docker run ...
+  annotate:
+    description: Run annotate command
+    service: backend
+    command: bundle exec annotate
+```
+
+Imagine `.dip` to be a submodule so it can be managed only in one place.
+
+If you want to override module command, you can redefine it in dip.yml
+
+```yml
+# ./dip.yml
+modules:
+ - sasts
+
+interaction:
+  brakeman:
+    description: Check brakeman sast
+    command: docker run another-image ...
+```
+
+```yml
+# ./.dip/sasts.yml
+interaction:
+  brakeman:
+    description: Check brakeman sast
+    command: docker run some-image ...
+```
+
+Will be expanded to:
+
+```yml
+# resultant configuration
+interaction:
+  brakeman:
+    description: Check brakeman sast
+    command: docker run another-image ...
+```
+
+Nested modules are not supported.
+
 ### dip run
 
 Run commands defined within the `interaction` section of dip.yml

--- a/spec/fixtures/modules/.dip/first.yml
+++ b/spec/fixtures/modules/.dip/first.yml
@@ -1,0 +1,3 @@
+interaction:
+  test_app:
+    service: test_backend

--- a/spec/fixtures/modules/.dip/last.yml
+++ b/spec/fixtures/modules/.dip/last.yml
@@ -1,0 +1,3 @@
+interaction:
+  test_app:
+    service: test_frontend

--- a/spec/fixtures/modules/.dip/test.yml
+++ b/spec/fixtures/modules/.dip/test.yml
@@ -1,0 +1,3 @@
+interaction:
+  app:
+    service: backend

--- a/spec/fixtures/modules/dip.yml
+++ b/spec/fixtures/modules/dip.yml
@@ -1,0 +1,17 @@
+version: '2'
+
+modules:
+  - first
+  - last
+  - test
+
+environment:
+  FOO: bar
+
+compose:
+  files:
+    - docker-compose.yml
+
+interaction:
+  app1:
+    service: frontend

--- a/spec/fixtures/unknown_module/dip.yml
+++ b/spec/fixtures/unknown_module/dip.yml
@@ -1,0 +1,4 @@
+version: '2'
+
+modules:
+  - unknown

--- a/spec/lib/dip/config_spec.rb
+++ b/spec/lib/dip/config_spec.rb
@@ -53,6 +53,30 @@ describe Dip::Config do
     end
   end
 
+  context "when config has modules", :env do
+    let(:env) { {"DIP_FILE" => fixture_path("modules", "dip.yml")} }
+
+    it "expands modules to main config" do
+      expect(subject.interaction[:app][:service]).to eq "backend"
+    end
+
+    it "merges modules to main config" do
+      expect(subject.interaction[:app1][:service]).to eq "frontend"
+    end
+
+    it "overrides first defined module with the last one" do
+      expect(subject.interaction[:test_app][:service]).to eq "test_frontend"
+    end
+  end
+
+  context "when config has unknown module", :env do
+    let(:env) { {"DIP_FILE" => fixture_path("unknown_module", "dip.yml")} }
+
+    it "raises and error" do
+      expect { subject.interaction }.to raise_error(Dip::Error, /Could not find module/)
+    end
+  end
+
   context "when config located two levels higher and overridden at one level higher", :env do
     subject { described_class.new(fixture_path("cascade", "sub_a", "sub_b")) }
 


### PR DESCRIPTION
# Context

Managing group of projects with `dip` is hard, imagine having multiple gems with such setup

```yml
interaction:
  brakeman:
    description: Check brakeman sast
    command: docker run ...
  gitleaks:
    description: Check gitleaks sast
    command: docker run ...
  bearer:
    description: Check bearer sast
    command: docker run ...
  trivy:
    description: Check trivy sast
    command: docker run ...
```

Every change in sast configuration leads to change in all `dip.yml` among gems.

## Related tickets

-

# What's inside

This PR introduces new concept of `modules`, modules are stored in `.dip` folder. This folder should be synced among group for example with git submodules, so it is stored in one place and synced among group.

Each module contains dip configuration so it can be splitted logically, e.g.

```yml
# ./.dip/sasts.yml
interaction:
  brakeman:
    description: Check brakeman sast
    command: docker run ...
  gitleaks:
    description: Check gitleaks sast
    command: docker run ...
  bearer:
    description: Check bearer sast
    command: docker run ...
  trivy:
    description: Check trivy sast
    command: docker run ...
```

Now sasts are managed in one place and can be included via modules.

```yml
# ./dip.yml
modules:
  - sasts

interaction:
  my_special_task:
     ....
```

See more examples in `README`

# Checklist:

- [x] I have added tests
- [x] I have made corresponding changes to the documentation
