### PR TITLE
Add validator to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Ruby
+name: CI
 
 on:
   push:
@@ -31,3 +31,16 @@ jobs:
         run: dip rubocop
       - name: Run tests
         run: dip rspec
+  schema-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 23
+      - name: Install dependencies
+        run: npm install -g ajv-cli
+      - name: Validate all dip.yml files
+        run: find . -type f -name 'dip.yml' | grep -v '/invalid' | xargs -I {} ajv -s schema.json -d {}

--- a/schema.json
+++ b/schema.json
@@ -94,7 +94,7 @@
           "type": "object",
           "description": "Contains subcommands with the same structure as main commands",
           "patternProperties": {
-            "^[\\w\\-\\.\\:\\/\\s]+$": {
+            "^[\\w\\-.:/\\s]+$": {
               "$ref": "#/definitions/interaction_command"
             }
           },
@@ -142,7 +142,7 @@
       "type": "object",
       "description": "Defines the commands and their configurations",
       "patternProperties": {
-        "^[\\w\\-\\.\\:\\/\\s]+$": {
+        "^[\\w\\-.:/\\s]+$": {
           "$ref": "#/definitions/interaction_command"
         }
       },
@@ -191,13 +191,13 @@
       "description": "Contains infrastructure services configuration",
       "additionalProperties": false,
       "patternProperties": {
-        "^[\\w\\-\\.\\:\\/\\s]+$": {
+        "^[\\w\\-.:/\\s]+$": {
           "type": "object",
           "additionalProperties": false,
           "properties": {
             "git": {
               "type": "string",
-              "pattern": "^(git@|git://|https?://)[\\w\\d\\.@:\\-/]+$",
+              "pattern": "^(git@|git://|https?://)[\\w\\d.@:/\\-]+$",
               "description": "Git repository URL for the infrastructure component",
               "examples": ["https://github.com/mycompany/redis-config.git"]
             },
@@ -220,5 +220,5 @@
       }
     }
   },
-  "required": ["version", "interaction"]
+  "required": ["version"]
 }


### PR DESCRIPTION
- The CI now checks all the dip.yml files in the repo against the schema to make sure they are in sync. 
- The newly introduced regexp resulted in `error: Invalid regular expression: /^[\w\-\.\:\/\s]+$/u: Invalid escape`.
- Renamed the workflow to `ci` since it now includes `schema-validate` which isn't Ruby related.
- The `interaction` key looks to be optional looking at some of the existing dip files.

The new action yields:

```
./spec/fixtures/empty/dip.yml valid
./spec/fixtures/no-schema/dip.yml valid
./spec/fixtures/missing/dip.yml valid
./spec/fixtures/cascade/dip.yml valid
./spec/fixtures/unknown_module/dip.yml valid
./spec/fixtures/overridden/dip.yml valid
./spec/fixtures/modules/dip.yml valid
./dip.yml valid
./examples/dip.yml valid
```