### PR TITLE
Reflect schema changes in `examples/dip.yml`

### DIFF
--- a/examples/dip.yml
+++ b/examples/dip.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bibendi/dip/refs/heads/master/schema.json
+
 version: '8.1.0'
 
 environment:
@@ -7,6 +9,8 @@ environment:
   REDIS_URL: redis://redis:6379/0
   PORT: ${PORT:-3000}
   APP_PORT: ${PORT:-3000}
+  ENABLE_WEB_CONSOLE: true
+  WORKER_CONCURRENCY: 4
 
 compose:
   files:
@@ -35,6 +39,10 @@ interaction:
     shell: true
     entrypoint: /docker-entrypoint.sh
     runner: docker_compose
+    pod: web
+    compose_run_options:
+      - service-ports
+      - rm
     subcommands:
       console:
         description: Start Rails console
@@ -82,6 +90,15 @@ interaction:
         - rm
       profiles:
         - test
+    subcommands:
+      all:
+        command: bundle exec appraisal rspec
+      rails-6.0:
+        command: bundle exec appraisal rails-6.0 rspec
+      rails-6.1:
+        command: bundle exec appraisal rails-6.1 rspec
+      rails-7.0:
+        command: bundle exec appraisal rails-7.0 rspec
 
   shell:
     description: Start a shell in the web container


### PR DESCRIPTION
I suggest we reflect the changes we make to the schema in `examples/dip.yml`. This ensure we don't break anything in the future and also allows new users to get an idea of what a (semi) complete configuration file would look like.

This works since the Github Action `schema-validate` runs the `schema.json` against the `examples/dip.yml`.