### PR TITLE
Fix some load errors related to different gem versions being available

### DIFF
--- a/lib/dip/config.rb
+++ b/lib/dip/config.rb
@@ -120,8 +120,8 @@ module Dip
       schema_path = File.join(File.dirname(__FILE__), "../../schema.json")
       raise Dip::Error, "Schema file not found: #{schema_path}" unless File.exist?(schema_path)
 
-      data = YAML.load_file(file_path)
-      schema = JSON.parse(File.read(schema_path))
+      data = self.class.load_yaml(file_path)
+      schema = JSON::Validator.parse(File.read(schema_path))
       JSON::Validator.validate!(schema, data)
     rescue Psych::SyntaxError => e
       raise Dip::Error, "Invalid YAML syntax in config file: #{e.message}"

--- a/lib/dip/config.rb
+++ b/lib/dip/config.rb
@@ -129,6 +129,8 @@ module Dip
       data_display = data ? data.to_yaml.gsub("\n", "\n  ") : "nil"
       error_message = "Schema validation failed: #{e.message}\nInput data:\n  #{data_display}"
       raise Dip::Error, error_message
+    rescue JSON::Schema::JsonParseError => e
+      raise Dip::Error, "Error parsing schema file: #{e.message}"
     end
 
     private


### PR DESCRIPTION
# Context

The functionality introduced via https://github.com/bibendi/dip/pull/176 is great, but it has some subtle interactions with other libraries that are causing breaking bugs for us:

- Depending on the version of `psych` loaded, using `YAML.load_file` directly won't work if the config file contains aliases
- If `MultiJson` is present, `JSON::Parser` may not exist yet

## Related tickets

- https://github.com/bibendi/dip/pull/176

# What's inside

<!--
List of features and changes (or highlights) (from the code perspective)
The purpose of this list is to track the progress if it's WIP (use checkboxes)
and to emphasize the critical parts (which you'd like to pay reviewers attention to)
-->
- Ensure we utilize the wrapper for `load_yaml` to deal with aliases properly
- Utilize `JSON::Validator.parse` as it handles MultiJson and other inconsistencies

# Checklist:

- [ ] I have added tests
  - Very difficult to add tests to this without moving to a multi-gemspec configuration.  Not sure if that's worth it for this (although it might be)
- [ ] I have made corresponding changes to the documentation
