### PR TITLE
fish shell support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches: [ '**' ]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -21,7 +18,7 @@ jobs:
     name: Ruby ${{ matrix.ruby }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Ruby w/ same version as image
         uses: ruby/setup-ruby@v1
         with:
@@ -37,7 +34,7 @@ jobs:
     name: RuboCop
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -52,11 +49,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: 23
+          node-version: 24
       - name: Install dependencies
         run: npm install -g ajv-cli
       - name: Validate all dip.yml files

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.4'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Added Fish shell support for `dip console` shell integration: `dip console | source`
 - Added `--shell` (`-s`) option to `dip console` / `dip console inject` to force the shell dialect (`bash`, `zsh`, `fish`); autodetected from `$SHELL` by default
 - Fixed `dip.yml` schema validation crashing on the `json` gem 3.0+ (Ruby 3.5+): `unknown keyword: quirks_mode`
+- Fixed shell integration (`dip console`) re-running `dip` on every `cd`, even within the same project — it now only reloads aliases when the resolved `dip.yml` actually changes
+- Fixed `dip console inject` paying for full `dip.yml` schema validation on every shell reload; it now only reads the interaction command names
 
 ## [8.3.0] - 2026-05-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed `dip.yml` schema validation crashing on the `json` gem 3.0+ (Ruby 3.5+): `unknown keyword: quirks_mode`
 - Fixed shell integration (`dip console`) re-running `dip` on every `cd`, even within the same project — it now only reloads aliases when the resolved `dip.yml` actually changes
 - Fixed `dip console inject` paying for full `dip.yml` schema validation on every shell reload; it now only reads the interaction command names
+- Fixed shell integration aliasing interaction commands over shell builtins/keywords (e.g. an interaction named `jobs` silently shadowed the `jobs` builtin, which prompts like Starship call on every render); such names are now skipped with a warning instead
 
 ## [8.3.0] - 2026-05-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+- Added Fish shell support for `dip console` shell integration: `dip console | source`
+- Added `--shell` (`-s`) option to `dip console` / `dip console inject` to force the shell dialect (`bash`, `zsh`, `fish`); autodetected from `$SHELL` by default
+- Fixed `dip.yml` schema validation crashing on the `json` gem 3.0+ (Ruby 3.5+): `unknown keyword: quirks_mode`
+
 ## [8.3.0] - 2026-05-23
 
 - Added `preflight` hook to run commands before `dip compose`, `dip run` and `dip ktl` [#188]

--- a/README.md
+++ b/README.md
@@ -36,11 +36,33 @@ gem install dip
 
 ### Integration with shell
 
-Dip can be injected into the current shell (ZSH or Bash).
+Dip can be injected into the current shell so that interaction commands (and `compose`, `up`, `stop`, `down`, `build`, `provision`) become available without the `dip` prefix. **Bash**, **ZSH**, and **Fish** are supported.
+
+Add the matching line to your shell startup file so the integration is loaded in every session:
 
 ```sh
+# Bash — ~/.bashrc or ~/.bash_profile
 eval "$(dip console)"
 ```
+
+```sh
+# ZSH — ~/.zshrc
+eval "$(dip console)"
+```
+
+```fish
+# Fish — ~/.config/fish/config.fish
+dip console | source
+```
+
+The target shell is autodetected from the `$SHELL` environment variable, so the snippets above work as-is. If autodetection is wrong (for example, you run Fish but `$SHELL` still points to Bash), force the dialect explicitly:
+
+```sh
+eval "$(dip console --shell zsh)"     # Bash / ZSH
+dip console --shell fish | source     # Fish
+```
+
+`--shell` accepts `bash`, `zsh`, or `fish` (`bash` and `zsh` produce the same POSIX output).
 
 **IMPORTANT**: Beware of possible collisions with local tools. One particular example is supporting both local and Docker frontend build tools, such as Yarn. If you want some developer to run `yarn` locally and other to use Docker for that, you should either avoid adding the `yarn` command to the `dip.yml` or avoid using the shell integration for hybrid development.
 
@@ -54,16 +76,27 @@ ktl *any-kubectl-arg
 provision
 ```
 
-When we change the current directory, all shell aliases will be automatically removed. But when we enter back into a directory with a `dip.yml` file, then shell aliases will be renewed.
+When we change the current directory, all shell aliases are automatically removed. When we enter a directory that has a `dip.yml` file (in it or in a parent), the aliases are renewed. This is wired through the shell's directory-change hook — `chpwd_functions` on ZSH, a `cd`/`pushd`/`popd` wrapper on Bash, and a `--on-variable PWD` handler on Fish.
 
-Also, in shell mode Dip is trying to determine manually passed environment variables. For example:
+Also, in shell mode Dip tries to determine manually passed environment variables. For example:
 
 ```sh
 VERSION=20180515103400 rails db:migrate:down
 ```
 
-You could add this `eval` at the end of your `~/.zshrc`, or `~/.bashrc`, or `~/.bash_profile`.
-After that, it will be automatically applied when you open your preferred terminal.
+Once the startup snippet is in place, the integration is applied automatically every time you open your terminal.
+
+#### How it works
+
+`dip console` prints a bootstrap script that defines three helpers:
+
+- `dip_inject` — evaluates `dip console inject`, which emits one shell function per interaction command plus the built-in `compose`/`up`/`stop`/`down`/`build`/`provision` wrappers.
+- `dip_clear` — removes the functions previously injected (regenerated on every inject so it always matches the current `dip.yml`).
+- `dip_reload` — runs `dip_clear` then `dip_inject`; also bound to the directory-change hook.
+
+The bootstrap also exports `DIP_SHELL=1`, `DIP_EARLY_ENVS` (the list of variables present at load time, used to detect manually passed env vars), and `DIP_PROMPT_TEXT` (`ⅆ`). On ZSH with the `agnoster` theme, `DIP_PROMPT_TEXT` is added as a prompt segment; other shells and themes are left untouched.
+
+You can force a reload at any time by running `dip_reload` (useful after editing `dip.yml`).
 
 ## Usage
 
@@ -508,6 +541,20 @@ If validation fails, you'll get detailed error messages indicating what needs to
 You can skip validation by setting `DIP_SKIP_VALIDATION` environment variable.
 
 Add `# yaml-language-server: $schema=https://raw.githubusercontent.com/bibendi/dip/refs/heads/master/schema.json` to the top of your dip.yml to get schema validation in VSCode. Read more about [YAML Language Server](https://github.com/redhat-developer/vscode-yaml?tab=readme-ov-file#associating-schemas).
+
+### dip console
+
+Prints the shell integration script for the current shell. See [Integration with shell](#integration-with-shell) for the full setup.
+
+```sh
+dip console [--shell bash|zsh|fish]          # bootstrap script (default subcommand)
+dip console inject [--shell bash|zsh|fish]   # just the command aliases
+```
+
+- `--shell` (`-s`) selects the dialect: `bash`, `zsh`, or `fish`. When omitted, it is autodetected from `$SHELL`, falling back to POSIX (Bash/ZSH) output.
+- `dip console` is meant to be evaluated by your shell: `eval "$(dip console)"` for Bash/ZSH, `dip console | source` for Fish.
+- `dip console inject` is called internally by the bootstrap script (via `dip_reload`); you normally don't run it by hand.
+
 ## Changelog
 
 See [CHANGELOG.md](CHANGELOG.md).

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ ktl *any-kubectl-arg
 provision
 ```
 
-When we change the current directory, all shell aliases are automatically removed. When we enter a directory that has a `dip.yml` file (in it or in a parent), the aliases are renewed. This is wired through the shell's directory-change hook — `chpwd_functions` on ZSH, a `cd`/`pushd`/`popd` wrapper on Bash, and a `--on-variable PWD` handler on Fish.
+When we change the current directory, all shell aliases are automatically removed. When we enter a directory that has a `dip.yml` file (in it or in a parent), the aliases are renewed. This is wired through the shell's directory-change hook — `chpwd_functions` on ZSH, a `cd`/`pushd`/`popd` wrapper on Bash, and a `--on-variable PWD` handler on Fish. The hook resolves the applicable `dip.yml` itself (no `dip` process involved) and only actually reloads when that path changes, so `cd`ing around inside the same project doesn't re-run `dip` on every prompt.
 
 Also, in shell mode Dip tries to determine manually passed environment variables. For example:
 
@@ -92,7 +92,7 @@ Once the startup snippet is in place, the integration is applied automatically e
 
 - `dip_inject` — evaluates `dip console inject`, which emits one shell function per interaction command plus the built-in `compose`/`up`/`stop`/`down`/`build`/`provision` wrappers.
 - `dip_clear` — removes the functions previously injected (regenerated on every inject so it always matches the current `dip.yml`).
-- `dip_reload` — runs `dip_clear` then `dip_inject`; also bound to the directory-change hook.
+- `dip_reload` — runs `dip_clear` then `dip_inject`; also bound to the directory-change hook, which calls it only when the resolved `dip.yml` path actually changed.
 
 The bootstrap also exports `DIP_SHELL=1`, `DIP_EARLY_ENVS` (the list of variables present at load time, used to detect manually passed env vars), and `DIP_PROMPT_TEXT` (`ⅆ`). On ZSH with the `agnoster` theme, `DIP_PROMPT_TEXT` is added as a prompt segment; other shells and themes are left untouched.
 
@@ -553,7 +553,7 @@ dip console inject [--shell bash|zsh|fish]   # just the command aliases
 
 - `--shell` (`-s`) selects the dialect: `bash`, `zsh`, or `fish`. When omitted, it is autodetected from `$SHELL`, falling back to POSIX (Bash/ZSH) output.
 - `dip console` is meant to be evaluated by your shell: `eval "$(dip console)"` for Bash/ZSH, `dip console | source` for Fish.
-- `dip console inject` is called internally by the bootstrap script (via `dip_reload`); you normally don't run it by hand.
+- `dip console inject` is called internally by the bootstrap script (via `dip_reload`); you normally don't run it by hand. It only needs the interaction command names, so it skips full `dip.yml` schema validation — run `dip validate` (or any other `dip` command) to check the file against the schema.
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Once the startup snippet is in place, the integration is applied automatically e
 
 `dip console` prints a bootstrap script that defines three helpers:
 
-- `dip_inject` — evaluates `dip console inject`, which emits one shell function per interaction command plus the built-in `compose`/`up`/`stop`/`down`/`build`/`provision` wrappers.
+- `dip_inject` — evaluates `dip console inject`, which emits one shell function per interaction command plus the built-in `compose`/`up`/`stop`/`down`/`build`/`provision` wrappers. An interaction command whose name collides with a shell builtin/keyword (`jobs`, `test`, `read`, `set`, …) is skipped, with a warning on stderr — run it as `dip <name>` instead, or rename it.
 - `dip_clear` — removes the functions previously injected (regenerated on every inject so it always matches the current `dip.yml`).
 - `dip_reload` — runs `dip_clear` then `dip_inject`; also bound to the directory-change hook, which calls it only when the resolved `dip.yml` path actually changed.
 

--- a/lib/dip/cli.rb
+++ b/lib/dip/cli.rb
@@ -143,7 +143,7 @@ module Dip
     subcommand :infra, Dip::CLI::Infra
 
     require_relative "cli/console"
-    desc "console", "Integrate Dip commands into shell (only ZSH and Bash are supported)"
+    desc "console", "Integrate Dip commands into shell (Bash, ZSH and Fish are supported)"
     subcommand :console, Dip::CLI::Console
   end
 end

--- a/lib/dip/cli/console.rb
+++ b/lib/dip/cli/console.rb
@@ -7,14 +7,21 @@ require_relative "../commands/console"
 module Dip
   class CLI
     class Console < Base
+      SHELL_OPTION = [
+        :shell,
+        {aliases: "-s", type: :string, enum: %w[bash zsh fish posix],
+         desc: "Target shell dialect (autodetected from $SHELL by default)"}
+      ].freeze
+
       desc "start", "Integrate Dip into current shell"
       method_option :help, aliases: "-h", type: :boolean,
         desc: "Display usage information"
+      method_option(*SHELL_OPTION)
       def start
         if options[:help]
           invoke :help, ["start"]
         else
-          Dip::Commands::Console::Start.new.execute
+          Dip::Commands::Console::Start.new(shell: options[:shell]).execute
         end
       end
 
@@ -23,11 +30,12 @@ module Dip
       desc "inject", "Inject aliases"
       method_option :help, aliases: "-h", type: :boolean,
         desc: "Display usage information"
+      method_option(*SHELL_OPTION)
       def inject
         if options[:help]
           invoke :help, ["inject"]
         else
-          Dip::Commands::Console::Inject.new.execute
+          Dip::Commands::Console::Inject.new(shell: options[:shell]).execute
         end
       end
     end

--- a/lib/dip/commands/console.rb
+++ b/lib/dip/commands/console.rb
@@ -5,6 +5,20 @@ require_relative "../command"
 module Dip
   module Commands
     module Console
+      # Interaction command names come straight from `dip.yml`, and `inject`
+      # turns each one into a same-named shell function. A name that collides
+      # with a shell builtin/keyword silently shadows it for the rest of the
+      # session — e.g. an interaction called `jobs` breaks `jobs`, which
+      # things like Starship's prompt call on every render, turning every
+      # keystroke into a `dip jobs` invocation. Skip those instead of
+      # aliasing over them.
+      RESERVED_NAMES = %w[
+        cd pwd test read set jobs type command builtin history alias unalias
+        source eval exec exit return break continue trap kill wait bg fg
+        export unset declare typeset readonly local shift times true false
+        echo printf time status functions function end
+      ].freeze
+
       # Figure out which shell dialect to generate integration code for.
       #
       # An explicit value (from `--shell`) always wins. Otherwise we guess from
@@ -234,6 +248,12 @@ module Dip
 
         def add_aliases(*names)
           names.each do |name|
+            if Console::RESERVED_NAMES.include?(name.to_s)
+              warn "dip: skipping alias `#{name}` — it would shadow the `#{name}` shell builtin. " \
+                "Run it as `#{Dip.bin_path} #{name}`, or rename it in dip.yml."
+              next
+            end
+
             aliases << name
             out << if fish?
               "function #{name}; #{Dip.bin_path} #{name} $argv; end"

--- a/lib/dip/commands/console.rb
+++ b/lib/dip/commands/console.rb
@@ -5,14 +5,36 @@ require_relative "../command"
 module Dip
   module Commands
     module Console
+      # Figure out which shell dialect to generate integration code for.
+      #
+      # An explicit value (from `--shell`) always wins. Otherwise we guess from
+      # the `$SHELL` environment variable and fall back to the POSIX flavour
+      # (bash/zsh) which was the only supported one historically.
+      def self.detect_shell(explicit = nil)
+        name = (explicit || File.basename(ENV["SHELL"].to_s)).to_s.downcase
+        name.include?("fish") ? :fish : :posix
+      end
+
       class Start < Dip::Command
+        def initialize(shell: nil)
+          @shell = Console.detect_shell(shell)
+        end
+
         def execute
-          puts script
+          puts fish? ? fish_script : posix_script
         end
 
         private
 
-        def script
+        def fish?
+          @shell == :fish
+        end
+
+        def inject_command
+          "#{Dip.bin_path} console inject --shell #{@shell}"
+        end
+
+        def posix_script
           <<-SH.gsub(/^ {12}/, "")
             export DIP_SHELL=1
             export DIP_EARLY_ENVS=#{ENV.keys.join(",")}
@@ -24,7 +46,7 @@ module Dip
             }
 
             function dip_inject() {
-              eval "$(#{Dip.bin_path} console inject)"
+              eval "$(#{inject_command})"
             }
 
             function dip_reload() {
@@ -75,12 +97,42 @@ module Dip
             dip_reload
           SH
         end
+
+        def fish_script
+          <<-FISH.gsub(/^ {12}/, "")
+            set -gx DIP_SHELL 1
+            set -gx DIP_EARLY_ENVS "#{ENV.keys.join(",")}"
+            set -gx DIP_PROMPT_TEXT "ⅆ"
+
+            function dip_clear
+              # just stub, will be redefined after injecting aliases
+              true
+            end
+
+            function dip_inject
+              #{inject_command} | source
+            end
+
+            function dip_reload
+              dip_clear
+              dip_inject
+            end
+
+            # Renew aliases whenever the working directory changes.
+            function __dip_chpwd --on-variable PWD
+              dip_reload
+            end
+
+            dip_reload
+          FISH
+        end
       end
 
       class Inject < Dip::Command
         attr_reader :out, :aliases
 
-        def initialize
+        def initialize(shell: nil)
+          @shell = Console.detect_shell(shell)
           @aliases = []
           @out = []
         end
@@ -98,17 +150,30 @@ module Dip
 
         private
 
+        def fish?
+          @shell == :fish
+        end
+
         def add_aliases(*names)
           names.each do |name|
             aliases << name
-            out << "function #{name}() { #{Dip.bin_path} #{name} $@; }"
+            out << if fish?
+              "function #{name}; #{Dip.bin_path} #{name} $argv; end"
+            else
+              "function #{name}() { #{Dip.bin_path} #{name} $@; }"
+            end
           end
         end
 
         def clear_aliases
-          out << "function dip_clear() { \n" \
-                  "#{aliases.any? ? aliases.map { |a| "  unset -f #{a}" }.join("\n") : "true"} " \
-                  "\n}"
+          out << if fish?
+            body = aliases.any? ? "functions -e #{aliases.join(" ")}" : "true"
+            "function dip_clear; #{body}; end"
+          else
+            "function dip_clear() { \n" \
+              "#{aliases.any? ? aliases.map { |a| "  unset -f #{a}" }.join("\n") : "true"} " \
+              "\n}"
+          end
         end
       end
     end

--- a/lib/dip/commands/console.rb
+++ b/lib/dip/commands/console.rb
@@ -54,6 +54,36 @@ module Dip
               dip_inject
             }
 
+            # Resolves the dip.yml that applies to $PWD (or $DIP_FILE), without
+            # spawning a `dip` process — used to skip redundant reloads below.
+            function __dip_config_path() {
+              if [ -n "${DIP_FILE:-}" ]; then
+                printf '%s\\n' "$DIP_FILE"
+                return
+              fi
+
+              \\typeset __dip_dir="$PWD"
+              while :; do
+                if [ -e "$__dip_dir/dip.yml" ]; then
+                  printf '%s\\n' "$__dip_dir/dip.yml"
+                  return
+                fi
+                [ "$__dip_dir" = "/" ] && return
+                __dip_dir=$(dirname "$__dip_dir")
+              done
+            }
+
+            # Only reload aliases on `cd` when the resolved dip.yml actually
+            # changed — most `cd`s stay within the same project and would
+            # otherwise re-spawn `dip` (Ruby boot + schema validation) for nothing.
+            function __dip_auto_reload() {
+              \\typeset __dip_new_config_path
+              __dip_new_config_path="$(__dip_config_path)"
+              [ "$__dip_new_config_path" = "${__DIP_CONFIG_PATH:-}" ] && return
+              __DIP_CONFIG_PATH="$__dip_new_config_path"
+              dip_reload
+            }
+
             # Inspired by RVM
             function __zsh_like_cd() {
               \\typeset __zsh_like_cd_hook
@@ -80,7 +110,7 @@ module Dip
             }
 
             export -a chpwd_functions
-            [[ " ${chpwd_functions[*]} " == *" dip_reload "* ]] || chpwd_functions+=(dip_reload)
+            [[ " ${chpwd_functions[*]} " == *" __dip_auto_reload "* ]] || chpwd_functions+=(__dip_auto_reload)
 
             if [[ "$ZSH_THEME" = "agnoster" ]]; then
               eval "`declare -f prompt_end | sed '1s/.*/_&/'`"
@@ -95,6 +125,7 @@ module Dip
             fi
 
             dip_reload
+            __DIP_CONFIG_PATH="$(__dip_config_path)"
           SH
         end
 
@@ -118,12 +149,41 @@ module Dip
               dip_inject
             end
 
-            # Renew aliases whenever the working directory changes.
+            # Resolves the dip.yml that applies to $PWD (or $DIP_FILE), without
+            # spawning a `dip` process — used to skip redundant reloads below.
+            function __dip_config_path
+              if set -q DIP_FILE
+                echo "$DIP_FILE"
+                return
+              end
+
+              set -l __dip_dir "$PWD"
+              while true
+                if test -e "$__dip_dir/dip.yml"
+                  echo "$__dip_dir/dip.yml"
+                  return
+                end
+                if test "$__dip_dir" = "/"
+                  return
+                end
+                set __dip_dir (dirname "$__dip_dir")
+              end
+            end
+
+            # Renew aliases whenever the working directory changes — but only
+            # when the resolved dip.yml actually changed. Most `cd`s stay within
+            # the same project and would otherwise re-spawn `dip` (Ruby boot +
+            # schema validation) for nothing.
             function __dip_chpwd --on-variable PWD
-              dip_reload
+              set -l __dip_new_config_path (__dip_config_path)
+              if test "$__dip_new_config_path" != "$__dip_config_path_cache"
+                set -g __dip_config_path_cache "$__dip_new_config_path"
+                dip_reload
+              end
             end
 
             dip_reload
+            set -g __dip_config_path_cache (__dip_config_path)
           FISH
         end
       end
@@ -138,9 +198,14 @@ module Dip
         end
 
         def execute
-          if Dip.config.exist?
-            add_aliases(*Dip.config.interaction.keys) if Dip.config.interaction
-            add_aliases("compose", "up", "stop", "down", "provision", "build")
+          # Runs on every automatic shell reload (e.g. on `cd`), so it only needs
+          # the interaction command names, not full schema conformance — skip the
+          # `json-schema` require and validation pass that every other command pays.
+          with_validation_skipped do
+            if Dip.config.exist?
+              add_aliases(*Dip.config.interaction.keys) if Dip.config.interaction
+              add_aliases("compose", "up", "stop", "down", "provision", "build")
+            end
           end
 
           clear_aliases
@@ -149,6 +214,19 @@ module Dip
         end
 
         private
+
+        def with_validation_skipped
+          had_key = ENV.key?("DIP_SKIP_VALIDATION")
+          previous = ENV["DIP_SKIP_VALIDATION"]
+          ENV["DIP_SKIP_VALIDATION"] = "1"
+          yield
+        ensure
+          if had_key
+            ENV["DIP_SKIP_VALIDATION"] = previous
+          else
+            ENV.delete("DIP_SKIP_VALIDATION")
+          end
+        end
 
         def fish?
           @shell == :fish

--- a/lib/dip/config.rb
+++ b/lib/dip/config.rb
@@ -3,6 +3,7 @@
 require "yaml"
 require "erb"
 require "pathname"
+require "json"
 require "json-schema"
 
 require "dip/version"
@@ -122,7 +123,9 @@ module Dip
       raise Dip::Error, "Schema file not found: #{schema_path}" unless File.exist?(schema_path)
 
       data = self.class.load_yaml(file_path)
-      schema = JSON::Validator.parse(File.read(schema_path))
+      # Parse with the stdlib rather than JSON::Validator.parse: the latter passes
+      # `quirks_mode:` to JSON.parse, which the json gem removed in 3.0 (Ruby 3.5+).
+      schema = JSON.parse(File.read(schema_path))
       JSON::Validator.validate!(schema, data)
     rescue Psych::SyntaxError => e
       raise Dip::Error, "Invalid YAML syntax in config file: #{e.message}"
@@ -130,7 +133,7 @@ module Dip
       data_display = data ? data.to_yaml.gsub("\n", "\n  ") : "nil"
       error_message = "Schema validation failed: #{e.message}\nInput data:\n  #{data_display}"
       raise Dip::Error, error_message
-    rescue JSON::Schema::JsonParseError => e
+    rescue JSON::Schema::JsonParseError, JSON::ParserError => e
       raise Dip::Error, "Error parsing schema file: #{e.message}"
     end
 

--- a/lib/dip/config.rb
+++ b/lib/dip/config.rb
@@ -4,7 +4,6 @@ require "yaml"
 require "erb"
 require "pathname"
 require "json"
-require "json-schema"
 
 require "dip/version"
 require "dip/ext/hash"
@@ -115,14 +114,19 @@ module Dip
       end
     end
 
-    def validate
+    # `data`, when given, is the already-parsed raw config (as produced by
+    # `load_yaml`) so callers that parsed the file themselves don't pay for
+    # parsing it a second time here.
+    def validate(data = nil)
       raise Dip::Error, "Config file path is not set" if file_path.nil?
       raise Dip::Error, "Config file not found: #{file_path}" unless File.exist?(file_path)
 
       schema_path = File.join(File.dirname(__FILE__), "../../schema.json")
       raise Dip::Error, "Schema file not found: #{schema_path}" unless File.exist?(schema_path)
 
-      data = self.class.load_yaml(file_path)
+      require "json-schema"
+
+      data ||= self.class.load_yaml(file_path)
       # Parse with the stdlib rather than JSON::Validator.parse: the latter passes
       # `quirks_mode:` to JSON.parse, which the json gem removed in 3.0 (Ruby 3.5+).
       schema = JSON.parse(File.read(schema_path))
@@ -182,7 +186,7 @@ module Dip
       @config = CONFIG_DEFAULTS.merge(base_config)
 
       unless ENV.key?("DIP_SKIP_VALIDATION")
-        validate
+        validate(config)
       end
 
       @config

--- a/spec/lib/dip/commands/console_spec.rb
+++ b/spec/lib/dip/commands/console_spec.rb
@@ -9,13 +9,39 @@ describe Dip::Commands::Console do
 
   describe Dip::Commands::Console::Start do
     context "when execute without start" do
-      subject { cli.start "console".shellsplit }
+      subject { cli.start "console --shell bash".shellsplit }
 
       it { expect { subject }.to output(/export DIP_SHELL=1/).to_stdout }
       it { expect { subject }.to output(/export DIP_EARLY_ENVS/).to_stdout }
       it { expect { subject }.to output(/function dip_clear/).to_stdout }
       it { expect { subject }.to output(/function dip_inject/).to_stdout }
       it { expect { subject }.to output(/function dip_reload/).to_stdout }
+      it { expect { subject }.to output(%r{console inject --shell posix}).to_stdout }
+    end
+
+    context "when the fish shell is requested" do
+      subject { cli.start "console --shell fish".shellsplit }
+
+      it { expect { subject }.to output(/set -gx DIP_SHELL 1/).to_stdout }
+      it { expect { subject }.to output(/set -gx DIP_EARLY_ENVS/).to_stdout }
+      it { expect { subject }.to output(/function dip_clear\n/).to_stdout }
+      it { expect { subject }.to output(/function dip_reload\n/).to_stdout }
+      it { expect { subject }.to output(/--on-variable PWD/).to_stdout }
+      it { expect { subject }.to output(%r{console inject --shell fish \| source}).to_stdout }
+      it { expect { subject }.not_to output(/export /).to_stdout }
+    end
+
+    context "when the shell is autodetected from $SHELL" do
+      subject { cli.start "console".shellsplit }
+
+      around do |example|
+        old = ENV["SHELL"]
+        ENV["SHELL"] = "/opt/homebrew/bin/fish"
+        example.run
+        ENV["SHELL"] = old
+      end
+
+      it { expect { subject }.to output(/set -gx DIP_SHELL 1/).to_stdout }
     end
   end
 
@@ -45,6 +71,24 @@ describe Dip::Commands::Console do
       it { expect { subject }.to output(/unset -f bash/).to_stdout }
       it { expect { subject }.to output(/function rails/).to_stdout }
       it { expect { subject }.to output(/unset -f rails/).to_stdout }
+    end
+  end
+
+  describe "#{Dip::Commands::Console::Inject} for fish" do
+    subject { cli.start "console inject --shell fish".shellsplit }
+
+    context "when provision commands are empty" do
+      it { expect { subject }.to output(/function compose; dip compose \$argv; end/).to_stdout }
+      it { expect { subject }.to output(/function provision; dip provision \$argv; end/).to_stdout }
+      it { expect { subject }.to output(/function dip_clear; functions -e .*compose.*; end/).to_stdout }
+      it { expect { subject }.not_to output(/unset -f/).to_stdout }
+    end
+
+    context "when has provision command", :config do
+      let(:config) { {interaction: {rails: {service: "app", command: "rails"}}} }
+
+      it { expect { subject }.to output(/function rails; dip rails \$argv; end/).to_stdout }
+      it { expect { subject }.to output(/functions -e rails /).to_stdout }
     end
   end
 end

--- a/spec/lib/dip/commands/console_spec.rb
+++ b/spec/lib/dip/commands/console_spec.rb
@@ -77,6 +77,26 @@ describe Dip::Commands::Console do
       it { expect { subject }.to output(/unset -f rails/).to_stdout }
     end
 
+    context "when an interaction command shadows a shell builtin", :config do
+      let(:config) { {interaction: {jobs: {service: "app", command: "bin/jobs start"}}} }
+
+      it "does not alias it" do
+        expect { subject }.not_to output(/function jobs/).to_stdout
+      end
+
+      it "does not try to unset it either" do
+        expect { subject }.not_to output(/unset -f jobs|functions -e .*jobs/).to_stdout
+      end
+
+      it "warns on stderr instead" do
+        expect { subject }.to output(/skipping alias `jobs`/).to_stderr
+      end
+
+      it "still aliases commands that don't collide" do
+        expect { subject }.to output(/function compose/).to_stdout
+      end
+    end
+
     it "does not run full schema validation (runs on every automatic shell reload)" do
       expect_any_instance_of(Dip::Config).not_to receive(:validate)
       subject

--- a/spec/lib/dip/commands/console_spec.rb
+++ b/spec/lib/dip/commands/console_spec.rb
@@ -17,6 +17,8 @@ describe Dip::Commands::Console do
       it { expect { subject }.to output(/function dip_inject/).to_stdout }
       it { expect { subject }.to output(/function dip_reload/).to_stdout }
       it { expect { subject }.to output(%r{console inject --shell posix}).to_stdout }
+      it { expect { subject }.to output(/function __dip_auto_reload/).to_stdout }
+      it { expect { subject }.to output(/chpwd_functions\+=\(__dip_auto_reload\)/).to_stdout }
     end
 
     context "when the fish shell is requested" do
@@ -29,6 +31,8 @@ describe Dip::Commands::Console do
       it { expect { subject }.to output(/--on-variable PWD/).to_stdout }
       it { expect { subject }.to output(%r{console inject --shell fish \| source}).to_stdout }
       it { expect { subject }.not_to output(/export /).to_stdout }
+      it { expect { subject }.to output(/function __dip_config_path/).to_stdout }
+      it { expect { subject }.to output(/set -g __dip_config_path_cache/).to_stdout }
     end
 
     context "when the shell is autodetected from $SHELL" do
@@ -71,6 +75,15 @@ describe Dip::Commands::Console do
       it { expect { subject }.to output(/unset -f bash/).to_stdout }
       it { expect { subject }.to output(/function rails/).to_stdout }
       it { expect { subject }.to output(/unset -f rails/).to_stdout }
+    end
+
+    it "does not run full schema validation (runs on every automatic shell reload)" do
+      expect_any_instance_of(Dip::Config).not_to receive(:validate)
+      subject
+    end
+
+    it "does not leak DIP_SKIP_VALIDATION into the environment afterwards" do
+      expect { subject }.not_to change { ENV.key?("DIP_SKIP_VALIDATION") }.from(false)
     end
   end
 


### PR DESCRIPTION
# Context

  - dip console shell integration only spoke POSIX (bash/zsh). Fish users had no way to inject dip aliases into their shell. This adds a Fish dialect, selected automatically from $SHELL or explicitly via a new --shell flag.
  - While wiring dip console inject up in a Fish session, I hit a pre-existing crash: dip.yml schema validation raises ArgumentError: unknown keyword: quirks_mode on the json gem 3.0+ (Ruby 3.5+, and any environment where bundler resolves json >= 3.0). This is also why the Ruby 2.7 CI job currently fails — it resolves json 3.0.2. Fixed here so the feature is actually usable.
  - The CI workflow still pins actions/checkout@v4 / actions/setup-node@v4, which now emit Node 20 deprecation warnings on every job. Bumped while here.

## Related tickets

- https://github.com/bibendi/dip/issues/187

# What's inside

  - [x] Fish output for dip console / dip console inject — set -gx exports, function … end aliases, functions -e teardown, and a --on-variable PWD event handler in place of the ZSH chpwd_functions / Bash cd wrapper. The ZSH-only bits (agnoster prompt segment, __zsh_like_cd) are omitted from the Fish script.
  - [x] --shell / -s option on console start and console inject (bash | zsh | fish). When omitted, the dialect is autodetected from $SHELL, falling back to POSIX. Start threads the resolved dialect into the dip console inject call it emits. Bash/ZSH output is byte-for-byte
    unchanged.
  - [x] Fix Dip::Config#validate crash on json 3.0+ — parse schema.json with stdlib JSON.parse instead of JSON::Validator.parse (which forwards the removed quirks_mode: kwarg); pass the resulting Hash straight to JSON::Validator.validate!. Also rescue JSON::ParserError alongside JSON::Schema::JsonParseError. 👉 reviewers: this is the behavioral change to sanity-check — validate! accepts a Hash schema directly, so validation semantics are identical.
  - [x] CI maintenance — actions/checkout@v4 → v5, actions/setup-node@v4 → v5, drop the now-unneeded FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 env shim, move schema-validate off EOL Node 23 to Node 24.
  - [x] Specs for every Fish path (start, inject with/without config, $SHELL autodetection, --shell enum rejection).
  - [x] README.md "Integration with shell" rewritten (per-shell setup, --shell, "How it works"), new dip console usage section, CHANGELOG.md entry.

# Checklist:

- [x] I have added tests
- [x] I have made corresponding changes to the documentation
